### PR TITLE
Some unit test improvements

### DIFF
--- a/test/mocked/raidenInspector.test.ts
+++ b/test/mocked/raidenInspector.test.ts
@@ -80,13 +80,13 @@ describe("Raiden inspector", () => {
     it("throws for expiry equal to dispute", async () => {
         const appointment = new RaidenAppointment({ ...appointmentObj, expiryPeriod: 10 });
         const inspector = new RaidenInspector(minimumDisputePeriod, provider);
-        expect(inspector.checkInspection(appointment)).eventually.be.rejected;
+        expect(inspector.checkInspection(appointment)).to.be.rejected;
     });
 
     it("throws for expiry less than dispute", async () => {
         const appointment = new RaidenAppointment({ ...appointmentObj, expiryPeriod: 9 });
         const inspector = new RaidenInspector(minimumDisputePeriod, provider);
-        expect(inspector.checkInspection(appointment)).eventually.be.rejected;
+        expect(inspector.checkInspection(appointment)).to.be.rejected;
     });
 
     it("throws for wrong additional hash", async () => {
@@ -99,7 +99,7 @@ describe("Raiden inspector", () => {
         });
 
         const inspector = new RaidenInspector(minimumDisputePeriod, provider);
-        expect(inspector.checkInspection(appointment)).eventually.be.rejected;
+        expect(inspector.checkInspection(appointment)).to.be.rejected;
     });
 
     it("throws for wrong balance hash", async () => {
@@ -111,7 +111,7 @@ describe("Raiden inspector", () => {
             stateUpdate: { ...appointmentObj.stateUpdate, balance_hash: wrongBalanceHash }
         });
         const inspector = new RaidenInspector(minimumDisputePeriod, provider);
-        expect(inspector.checkInspection(appointment)).eventually.be.rejected;
+        expect(inspector.checkInspection(appointment)).to.be.rejected;
     });
 
     it("throws for incorrect channel identifier", async () => {
@@ -121,7 +121,7 @@ describe("Raiden inspector", () => {
         });
 
         const inspector = new RaidenInspector(minimumDisputePeriod, provider);
-        expect(inspector.checkInspection(appointment)).eventually.be.rejected;
+        expect(inspector.checkInspection(appointment)).to.be.rejected;
     });
 
     it("throws for incorrect closing participant", async () => {
@@ -134,7 +134,7 @@ describe("Raiden inspector", () => {
         });
 
         const inspector = new RaidenInspector(minimumDisputePeriod, provider);
-        expect(inspector.checkInspection(appointment)).eventually.be.rejected;
+        expect(inspector.checkInspection(appointment)).to.be.rejected;
     });
 
     it("throws for wrong closing participant sig", async () => {
@@ -147,7 +147,7 @@ describe("Raiden inspector", () => {
         });
 
         const inspector = new RaidenInspector(minimumDisputePeriod, provider);
-        expect(inspector.checkInspection(appointment)).eventually.be.rejected;
+        expect(inspector.checkInspection(appointment)).to.be.rejected;
     });
 
     it("throws for incorrect non_closing participant", async () => {
@@ -158,7 +158,7 @@ describe("Raiden inspector", () => {
             stateUpdate: { ...appointmentObj.stateUpdate, non_closing_participant: wrongNonClosingParticipant }
         });
         const inspector = new RaidenInspector(minimumDisputePeriod, provider);
-        expect(inspector.checkInspection(appointment)).eventually.be.rejected;
+        expect(inspector.checkInspection(appointment)).to.be.rejected;
     });
 
     it("throws for wrong non_closing participant sig", async () => {
@@ -172,7 +172,7 @@ describe("Raiden inspector", () => {
         });
 
         const inspector = new RaidenInspector(minimumDisputePeriod, provider);
-        expect(inspector.checkInspection(appointment)).eventually.be.rejected;
+        expect(inspector.checkInspection(appointment)).to.be.rejected;
     });
 
     it("throws for nonce too low", async () => {
@@ -182,7 +182,7 @@ describe("Raiden inspector", () => {
         });
 
         const inspector = new RaidenInspector(minimumDisputePeriod, provider);
-        expect(inspector.checkInspection(appointment)).eventually.be.rejected;
+        expect(inspector.checkInspection(appointment)).to.be.rejected;
     });
 
     it("throws for wrong chain id", async () => {
@@ -191,7 +191,7 @@ describe("Raiden inspector", () => {
             stateUpdate: { ...appointmentObj.stateUpdate, chain_id: 4 }
         });
         const inspector = new RaidenInspector(minimumDisputePeriod, provider);
-        expect(inspector.checkInspection(appointment)).eventually.be.rejected;
+        expect(inspector.checkInspection(appointment)).to.be.rejected;
     });
 
     it("throws for wrong token network id", async () => {
@@ -203,7 +203,7 @@ describe("Raiden inspector", () => {
             }
         });
         const inspector = new RaidenInspector(minimumDisputePeriod, provider);
-        expect(inspector.checkInspection(appointment)).eventually.be.rejected;
+        expect(inspector.checkInspection(appointment)).to.be.rejected;
     });
 
     it("throws for no code returned", async () => {
@@ -216,7 +216,7 @@ describe("Raiden inspector", () => {
             }
         });
         const inspector = new RaidenInspector(minimumDisputePeriod, provider);
-        expect(inspector.checkInspection(appointment)).eventually.be.rejected;
+        expect(inspector.checkInspection(appointment)).to.be.rejected;
     });
 
     it("throws for wrong code returned", async () => {
@@ -229,6 +229,6 @@ describe("Raiden inspector", () => {
             }
         });
         const inspector = new RaidenInspector(minimumDisputePeriod, provider);
-        expect(inspector.checkInspection(appointment)).eventually.be.rejected;
+        expect(inspector.checkInspection(appointment)).to.be.rejected;
     });
 });

--- a/test/src/kitsuneInspector.test.ts
+++ b/test/src/kitsuneInspector.test.ts
@@ -76,7 +76,7 @@ describe("Inspector", () => {
                     type: ChannelType.Kitsune
                 })
             )
-        ).to.eventually.be.rejected;
+        ).to.be.rejected;
     });
 
     it("throws for expiry equal dispute time", async () => {
@@ -100,7 +100,7 @@ describe("Inspector", () => {
                     type: ChannelType.Kitsune
                 })
             )
-        ).to.eventually.be.rejected;
+        ).to.be.rejected;
     });
 
     it("throws for expiry less than dispute time", async () => {
@@ -124,7 +124,7 @@ describe("Inspector", () => {
                     type: ChannelType.Kitsune
                 })
             )
-        ).to.eventually.be.rejected;
+        ).to.be.rejected;
     });
 
     it("throws for non existant contract", async () => {
@@ -149,7 +149,7 @@ describe("Inspector", () => {
                     type: ChannelType.Kitsune
                 })
             )
-        ).to.eventually.be.rejected;
+        ).to.be.rejected;
     });
 
     it("throws for wrong state hash", async () => {
@@ -174,7 +174,7 @@ describe("Inspector", () => {
                     type: ChannelType.Kitsune
                 })
             )
-        ).to.eventually.be.rejected;
+        ).to.be.rejected;
     });
 
     it("throws for sigs on wrong hash", async () => {
@@ -199,7 +199,7 @@ describe("Inspector", () => {
                     type: ChannelType.Kitsune
                 })
             )
-        ).to.eventually.be.rejected;
+        ).to.be.rejected;
     });
 
     it("throws for sigs by only one player", async () => {
@@ -224,7 +224,7 @@ describe("Inspector", () => {
                     type: ChannelType.Kitsune
                 })
             )
-        ).to.eventually.be.rejected;
+        ).to.be.rejected;
     });
 
     it("throws for missing sig", async () => {
@@ -248,7 +248,7 @@ describe("Inspector", () => {
                     type: ChannelType.Kitsune
                 })
             )
-        ).to.eventually.be.rejected;
+        ).to.be.rejected;
     });
 
     it("accepts sigs in wrong order", async () => {

--- a/test/src/responder.test.ts
+++ b/test/src/responder.test.ts
@@ -498,7 +498,7 @@ describe("EthereumTransactionMiner", async () => {
 
         const res = miner.sendTransaction(transactionRequest);
 
-        return expect(res).to.eventually.be.rejectedWith(error);
+        return expect(res).to.be.rejectedWith(error);
     });
 
     it("waitForFirstConfirmation resolves after the transaction is confirmed", async () => {
@@ -509,7 +509,7 @@ describe("EthereumTransactionMiner", async () => {
         
         await mineBlock(ganache, provider);
 
-        return expect(res).to.eventually.be.fulfilled;
+        return expect(res).to.be.fulfilled;
     });
 
     it("waitForFirstConfirmation throws NoNewBlockError after timeout", async () => {
@@ -519,7 +519,7 @@ describe("EthereumTransactionMiner", async () => {
 
         const res = miner.waitForFirstConfirmation(txHash, Date.now());
 
-        return expect(res).to.eventually.be.rejectedWith(NoNewBlockError);
+        return expect(res).to.be.rejectedWith(NoNewBlockError);
     });
 
     it("waitForFirstConfirmation throws BlockThresholdReachedError if the transaction is stuck", async () => {
@@ -535,7 +535,7 @@ describe("EthereumTransactionMiner", async () => {
             provider.emit("block", blockNumber + 1 + i)
         }
 
-        return expect(res).to.eventually.be.rejectedWith(BlockThresholdReachedError);
+        return expect(res).to.be.rejectedWith(BlockThresholdReachedError);
     });
 
     it("waitForEnoughConfirmations resolves after enough confirmations", async () => {
@@ -554,7 +554,7 @@ describe("EthereumTransactionMiner", async () => {
             await mineBlock(ganache, provider);
         }
 
-        return expect(res).to.eventually.be.fulfilled;
+        return expect(res).to.be.fulfilled;
     });
 
     it("waitForEnoughConfirmations throws NoNewBlockError after timeout", async () => {
@@ -565,8 +565,9 @@ describe("EthereumTransactionMiner", async () => {
         mineBlock(ganache, provider);
         await miner.waitForFirstConfirmation(txHash, Date.now());
 
-        const res = miner.waitForEnoughConfirmations(txHash, Date.now());
-        return expect(res).to.eventually.be.rejectedWith(NoNewBlockError);
+        return expect(
+            miner.waitForEnoughConfirmations(txHash, Date.now())
+        ).to.be.rejectedWith(NoNewBlockError);
     });
 
     it("waitForEnoughConfirmations throws ReorgError if the transaction is not found by the provider", async () => {
@@ -587,6 +588,6 @@ describe("EthereumTransactionMiner", async () => {
         // Mine another block
         mineBlock(ganache, provider);
 
-        return expect(res).to.eventually.be.rejectedWith(ReorgError);
+        return expect(res).to.be.rejectedWith(ReorgError);
     });
 });

--- a/test/src/responder.test.ts
+++ b/test/src/responder.test.ts
@@ -514,7 +514,7 @@ describe("EthereumTransactionMiner", async () => {
 
     it("waitForFirstConfirmation throws NoNewBlockError after timeout", async () => {
         const noNewBlockTimeout = 20; // very short timeout for the test
-        const miner = new EthereumTransactionMiner(account0Signer, 5, 10, noNewBlockTimeout, 20);
+        const miner = new EthereumTransactionMiner(account0Signer, 5, 10, noNewBlockTimeout, 100);
         const txHash = await miner.sendTransaction(transactionRequest);
 
         const res = miner.waitForFirstConfirmation(txHash, Date.now());
@@ -559,7 +559,7 @@ describe("EthereumTransactionMiner", async () => {
 
     it("waitForEnoughConfirmations throws NoNewBlockError after timeout", async () => {
         const noNewBlockTimeout = 20; // very short timeout for the test
-        const miner = new EthereumTransactionMiner(account0Signer, 5, 10, noNewBlockTimeout, 20);
+        const miner = new EthereumTransactionMiner(account0Signer, 5, 10, noNewBlockTimeout, 100);
         const txHash = await miner.sendTransaction(transactionRequest);
 
         mineBlock(ganache, provider);


### PR DESCRIPTION
- Removed use of ".eventually" in chai-as-promised tests for fulfilled/rejected.
- Increased polling time for two tests that were occasionally failing, especially on circleci; hopefully they won't after this Not fully sure why they failed, though.