### PR TITLE
Add appointment signatures to Pisa tower responses

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -5,6 +5,7 @@
         "port": 3000
     },
     "responderKey": "0x6370fd033278c143179d81c5526140625662b8daa446c22ee2d73db3707e620c",
+    "receiptKey": "0x6370fd033278c143179d81c5526140625662b8daa446c22ee2d73db3707e620c",
     "apiEndpoint": {
         "rateGlobal": {
             "windowMs": 60000,

--- a/src/dataEntities/config.ts
+++ b/src/dataEntities/config.ts
@@ -1,25 +1,26 @@
 import config from "../config.json";
 
 interface IRateConfig {
-    windowMs: number;
-    max: number;
-    message?: string;
+    windowMs: number; // size of the rate limit window in milliseconds
+    max: number; // maximum number of requests in the time window
+    message?: string; // if given, overrides the default message returned in case a user is affected by the rate limit
 }
 
 export interface IApiEndpointConfig {
-    rateGlobal?: IRateConfig;
-    ratePerUser?: IRateConfig;
+    rateGlobal?: IRateConfig; // global rate limit
+    ratePerUser?: IRateConfig; // per-user rate limit
 }
 
 export interface IConfig {
     jsonRpcUrl: string;
-    host: {
+    host: { // hostname and port for Pisa's API endpoint
         name: string;
         port: number;
     },
-    responderKey: string;
-    apiEndpoint?: IApiEndpointConfig;
-    dbDir: string
+    responderKey: string; // private key used for responding to disputes
+    receiptKey: string; // private key used to sign receipts
+    apiEndpoint?: IApiEndpointConfig; // configuration of the API endpoint
+    dbDir: string;
 }
 
 export default config as IConfig;

--- a/src/service.ts
+++ b/src/service.ts
@@ -181,7 +181,7 @@ export class PisaService extends StartStopService {
                 // with signature
                 res.send({
                     appointment,
-                    signatures: [signature]
+                    signature
                 });
             } catch (doh) {
                 if (doh instanceof PublicInspectionError) this.logAndSend(400, doh.message, doh, res);

--- a/src/startUp.ts
+++ b/src/startUp.ts
@@ -93,19 +93,24 @@ async function startUp() {
     await validateProvider(provider)
     await validateProvider(delayedProvider)
 
+    const receiptSigner = new ethers.Wallet(config.receiptKey); 
+
     // start the pisa service
     const service = new PisaService(
         config.host.name,
         config.host.port,
         provider,
         watcherWallet,
+        receiptSigner,
         delayedProvider,
         db,
         config.apiEndpoint
     );
 
-    // wait for a stop signal
-    waitForStop(service);
+    service.start().then(a => {
+        // wait for a stop signal
+        waitForStop(service);
+    });
 }
 
 function waitForStop(service: PisaService) {

--- a/src/tower.ts
+++ b/src/tower.ts
@@ -74,7 +74,6 @@ export class HotEthereumAppointmentSigner extends EthereumAppointmentSigner {
      * @param appointment
      */
     public signAppointment(appointment: EthereumAppointment): Promise<string> {
-        // TODO: this signature format does not match Pisa's contract
         const packedData = ethers.utils.solidityPack([
             'address',
             'string',

--- a/test/src/serviceEndToEnd.test.ts
+++ b/test/src/serviceEndToEnd.test.ts
@@ -116,7 +116,7 @@ describe("Service end-to-end", () => {
         }
     }).timeout(3000);
 
-    it("contains 'appointment' and 'signatures' in the response; signature is correct", async () => {
+    it("contains 'appointment' and 'signature' in the response; signature is correct", async () => {
         const round = 1,
             setStateHash = KitsuneTools.hashForSetState(hashState, round, channelContract.address),
             sig0 = await provider.getSigner(account0).signMessage(ethers.utils.arrayify(setStateHash)),
@@ -150,8 +150,8 @@ describe("Service end-to-end", () => {
         const signer = new Wallet(config.receiptKey!);
         const sig = await signer.signMessage(digest);
 
-        expect(res).to.include.all.keys("appointment", "signatures");
-        expect(res.signatures[0]).to.equal(sig);
+        expect(res).to.include.all.keys("appointment", "signature");
+        expect(res.signature).to.equal(sig);
     });
 
     it("create channel, submit round = 0 too low returns 400", async () => {


### PR DESCRIPTION
Added receiptKey in config as a key to sign (Ethereum) accepted appointments.

PisaService uses a receiptKey in the config to create a Wallet.
PisaTower, instead, expects an EthereumAppointmentSigner, that knows how to sign appointments.

The reason for the different interface is that future PisaService implementations _will not_ have access to the signer at all, but it useful for now, since a pisa service bundles all the pieces together in one service. Instead, the Tower _will_ have access to some signing authority, but how to get the appointments signed is out of its concern and encapsulated in the EthereumAppointmentSigner.