### PR TITLE
Make the BlockCache accessible via the interface of BlockProcessor; make sure that the head of the blockProcessor is always initialized

### DIFF
--- a/src/blockMonitor/blockCache.ts
+++ b/src/blockMonitor/blockCache.ts
@@ -19,23 +19,23 @@ import { IBlockStub, BlockStubChain } from "./blockStub";
  * Note that in order to guarantee the invariant (1), `addBlock` can be safely called even for blocks that will not
  * actually be added (for example because they are already too deep); in that case, it will return `false`.
  **/
-export class BlockCache {
-    private blockStubsByHash: Map<string, BlockStubChain> = new Map();
+export abstract class ReadOnlyBlockCache {
+    protected blockStubsByHash: Map<string, BlockStubChain> = new Map();
 
     // set of tx hashes per block hash, for fast lookup
-    private txHashesByBlockHash: Map<string, Set<string>> = new Map();
+    protected txHashesByBlockHash: Map<string, Set<string>> = new Map();
 
     // store block hashes at a specific height (there could be more than one at some height because of forks)
-    private blockHashesByHeight: Map<number, Set<string>> = new Map();
+    protected blockHashesByHeight: Map<number, Set<string>> = new Map();
 
     // Next height to be pruned; the cache will not store a block with height strictly smaller than pruneHeight
-    private pruneHeight: number;
+    protected pruneHeight: number;
 
     // True before the first block ever is added
-    private isEmpty = true;
+    protected isEmpty = true;
 
     // Height of the highest known block
-    private mMaxHeight = 0;
+    protected mMaxHeight = 0;
     public get maxHeight() {
         return this.mMaxHeight;
     }
@@ -58,7 +58,7 @@ export class BlockCache {
     constructor(public readonly maxDepth: number) {}
 
     // Removes all info related to a block in blockStubsByHash and txHashesByBlockHash
-    private removeBlock(blockHash: string) {
+    protected removeBlock(blockHash: string) {
         const block = this.blockStubsByHash.get(blockHash);
         if (!block) {
             // This would signal a bug
@@ -75,7 +75,7 @@ export class BlockCache {
     }
 
     // Remove all the blocks that are deeper than maxDepth, and all connected information.
-    private prune() {
+    protected prune() {
         while (this.pruneHeight < this.minHeight) {
             for (const hash of this.blockHashesByHeight.get(this.pruneHeight) || []) {
                 this.removeBlock(hash);
@@ -87,7 +87,7 @@ export class BlockCache {
     }
 
     // Makes a new block stub, linking the parent if available
-    private makeBlockStub(hash: string, number: number, parentHash: string) {
+    protected makeBlockStub(hash: string, number: number, parentHash: string) {
         const parentBlockStubChain = this.blockStubsByHash.get(parentHash);
         let newBlockStubChain: BlockStubChain;
         if (parentBlockStubChain === undefined) {
@@ -114,7 +114,7 @@ export class BlockCache {
      * Here we check that the block is not actually already added, and it is not below a height
      * that would be pruned immediately.
      */
-    private shouldAddBlock(block: ethers.providers.Block) {
+    protected shouldAddBlock(block: ethers.providers.Block) {
         if (this.blockStubsByHash.has(block.hash)) {
             // block already in memory
             return false;
@@ -124,53 +124,6 @@ export class BlockCache {
             // block too deep
             return false;
         }
-        return true;
-    }
-
-    /**
-     * Adds `block`to the cache.
-     * @param block
-     * @returns `true` if the block was added, `false` if the block was not added (because too deep or already in cache).
-     * @throws `ApplicationError` if the block cannot be added because its parent is not in cache.
-     */
-    public addBlock(block: ethers.providers.Block): boolean {
-        // If the block's parent is above the minimum visible height, it needs to be added first
-        if (!this.canAddBlock(block)) {
-            throw new ApplicationError("Tried to add a block before its parent block.");
-        }
-
-        if (this.isEmpty) {
-            // First block added, store its height, so blocks before this point will not be stored.
-            this.pruneHeight = block.number;
-            this.isEmpty = false;
-        } else if (!this.shouldAddBlock(block)) {
-            // We do not actually need to add the block
-            return false;
-        }
-
-        // Update data structures
-
-        // Save block stub
-        const newBlockStub = this.makeBlockStub(block.hash, block.number, block.parentHash);
-        this.blockStubsByHash.set(block.hash, newBlockStub);
-
-        // Add set of transactions for this block hash
-        this.txHashesByBlockHash.set(block.hash, new Set(block.transactions));
-
-        // Index block by its height
-        const hashesByHeight = this.blockHashesByHeight.get(block.number);
-        if (hashesByHeight === undefined) {
-            this.blockHashesByHeight.set(block.number, new Set([block.hash]));
-        } else {
-            hashesByHeight.add(block.hash);
-        }
-
-        // If the maximum block height increased, we might have to prune some old info
-        if (this.mMaxHeight < block.number) {
-            this.mMaxHeight = block.number;
-            this.prune();
-        }
-
         return true;
     }
 
@@ -220,5 +173,54 @@ export class BlockCache {
 
         // Not found
         return 0;
+    }
+}
+
+export class BlockCache extends ReadOnlyBlockCache {
+    /**
+     * Adds `block`to the cache.
+     * @param block
+     * @returns `true` if the block was added, `false` if the block was not added (because too deep or already in cache).
+     * @throws `ApplicationError` if the block cannot be added because its parent is not in cache.
+     */
+    public addBlock(block: ethers.providers.Block): boolean {
+        // If the block's parent is above the minimum visible height, it needs to be added first
+        if (!this.canAddBlock(block)) {
+            throw new ApplicationError("Tried to add a block before its parent block.");
+        }
+
+        if (this.isEmpty) {
+            // First block added, store its height, so blocks before this point will not be stored.
+            this.pruneHeight = block.number;
+            this.isEmpty = false;
+        } else if (!this.shouldAddBlock(block)) {
+            // We do not actually need to add the block
+            return false;
+        }
+
+        // Update data structures
+
+        // Save block stub
+        const newBlockStub = this.makeBlockStub(block.hash, block.number, block.parentHash);
+        this.blockStubsByHash.set(block.hash, newBlockStub);
+
+        // Add set of transactions for this block hash
+        this.txHashesByBlockHash.set(block.hash, new Set(block.transactions));
+
+        // Index block by its height
+        const hashesByHeight = this.blockHashesByHeight.get(block.number);
+        if (hashesByHeight === undefined) {
+            this.blockHashesByHeight.set(block.number, new Set([block.hash]));
+        } else {
+            hashesByHeight.add(block.hash);
+        }
+
+        // If the maximum block height increased, we might have to prune some old info
+        if (this.mMaxHeight < block.number) {
+            this.mMaxHeight = block.number;
+            this.prune();
+        }
+
+        return true;
     }
 }

--- a/src/blockMonitor/confirmationObserver.ts
+++ b/src/blockMonitor/confirmationObserver.ts
@@ -65,8 +65,8 @@ export class ConfirmationObserver extends StartStopService {
             );
         }
 
-        const headHash = this.blockProcessor.head && this.blockProcessor.head.hash;
-        if (headHash && blockCache.getConfirmations(headHash, txHash) >= nConfirmations) {
+        const headHash = this.blockProcessor.head.hash;
+        if (blockCache.getConfirmations(headHash, txHash) >= nConfirmations) {
             // already has enough confirmations, resolve immediately
             return new CancellablePromise(resolve => resolve());
         }
@@ -81,7 +81,7 @@ export class ConfirmationObserver extends StartStopService {
      **/
     public waitForBlocks(nBlocks: number) {
         // store the current height, or null if not known (will be set later);
-        let initialHeight = this.blockProcessor.head && this.blockProcessor.head.number;
+        let initialHeight = this.blockProcessor.head.number;
 
         return this.listenForPredicate((blockNumber, _) => {
             if (initialHeight === null) {

--- a/src/blockMonitor/index.ts
+++ b/src/blockMonitor/index.ts
@@ -1,5 +1,5 @@
 export { BlockStubChain, IBlockStub } from "./blockStub";
-export { BlockCache } from "./blockCache";
+export { ReadOnlyBlockCache, BlockCache } from "./blockCache";
 export { BlockProcessor } from "./blockProcessor";
 export { ReorgDetector } from "./reorgDetector";
 export { ConfirmationObserver } from "./confirmationObserver";

--- a/src/blockMonitor/reorgDetector.ts
+++ b/src/blockMonitor/reorgDetector.ts
@@ -1,7 +1,6 @@
 import { ethers } from "ethers";
 import { ArgumentError, StartStopService } from "../dataEntities";
 import { BlockStubChain, IBlockStub } from "./blockStub";
-import { BlockCache } from "./blockCache";
 import { ReorgHeightListenerStore } from "./reorgHeightListener";
 import { BlockProcessor } from "./blockProcessor";
 
@@ -16,7 +15,7 @@ export class ReorgDetector extends StartStopService {
     private conductingReorg: boolean = false;
 
     public get maxDepth() {
-        return this.blockCache.maxDepth;
+        return this.blockProcessor.blockCache.maxDepth;
     }
 
     /**
@@ -45,7 +44,6 @@ export class ReorgDetector extends StartStopService {
     constructor(
         private readonly provider: ethers.providers.BaseProvider,
         private readonly blockProcessor: BlockProcessor,
-        private readonly blockCache: BlockCache,
         public readonly store: ReorgHeightListenerStore
     ) {
         super("reorg-detector");
@@ -72,7 +70,7 @@ export class ReorgDetector extends StartStopService {
 
         try {
             // get the full block information for the incoming block
-            const fullBlock = this.blockCache.getBlockStub(blockHash)!;
+            const fullBlock = this.blockProcessor.blockCache.getBlockStub(blockHash)!;
 
             if (!this.headBlock) {
                 // no current block - start of operation
@@ -199,7 +197,7 @@ export class ReorgDetector extends StartStopService {
         differenceBlocks: IBlockStub[],
         minHeight: number
     ): BlockStubChain | null {
-        const blockRemote = this.blockCache.getBlockStub(remoteBlockHash);
+        const blockRemote = this.blockProcessor.blockCache.getBlockStub(remoteBlockHash);
         if (!blockRemote) return null;
         differenceBlocks.push(blockRemote);
         if (blockRemote.number <= minHeight) return null;

--- a/src/service.ts
+++ b/src/service.ts
@@ -73,12 +73,7 @@ export class PisaService extends StartStopService {
         // start reorg detector and block monitor
         const blockCache = new BlockCache(200);
         this.blockProcessor = new BlockProcessor(delayedProvider, blockCache);
-        this.reorgDetector = new ReorgDetector(
-            delayedProvider,
-            this.blockProcessor,
-            blockCache,
-            new ReorgHeightListenerStore()
-        );
+        this.reorgDetector = new ReorgDetector(delayedProvider, this.blockProcessor, new ReorgHeightListenerStore());
 
         // dependencies
         this.appointmentStore = new AppointmentStore(
@@ -86,7 +81,7 @@ export class PisaService extends StartStopService {
             new Map(configs.map<[ChannelType, (obj: any) => IEthereumAppointment]>(c => [c.channelType, c.appointment]))
         );
         this.blockTimeoutDetector = new BlockTimeoutDetector(this.blockProcessor, 120 * 1000);
-        this.confirmationObserver = new ConfirmationObserver(blockCache, this.blockProcessor);
+        this.confirmationObserver = new ConfirmationObserver(this.blockProcessor);
         this.ethereumResponderManager = new EthereumResponderManager(
             wallet,
             this.blockTimeoutDetector,

--- a/test/src/blockMonitor/blockCache.test.ts
+++ b/test/src/blockMonitor/blockCache.test.ts
@@ -1,6 +1,6 @@
 import "mocha";
 import { expect } from "chai";
-import { BlockCache, IBlockStub } from "../../../src/blockMonitor";
+import { BlockCache } from "../../../src/blockMonitor";
 import { ethers } from "ethers";
 
 function generateBlocks(nBlocks: number, initialHeight: number, chain: string): ethers.providers.Block[] {

--- a/test/src/blockMonitor/confirmationObserver.test.ts
+++ b/test/src/blockMonitor/confirmationObserver.test.ts
@@ -98,7 +98,12 @@ describe("ConfirmationObserver", () => {
             writable: true
         });
 
-        confirmationObserver = new ConfirmationObserver(blockCache, mockBlockProcessor);
+        Object.defineProperty(mockBlockProcessor, "blockCache", {
+            value: blockCache,
+            writable: false
+        });
+
+        confirmationObserver = new ConfirmationObserver(mockBlockProcessor);
         await confirmationObserver.start();
     });
 

--- a/test/src/blockMonitor/confirmationObserver.test.ts
+++ b/test/src/blockMonitor/confirmationObserver.test.ts
@@ -124,10 +124,11 @@ describe("ConfirmationObserver", () => {
     });
 
     it("waitForConfirmations resolves after the right amount of confirmations, but not before", async () => {
+        await emitNewHead("a1");
+
         const p = new PromiseSpy(confirmationObserver.waitForConfirmations(txHash, 4));
         await Promise.resolve(); // flush promises
 
-        await emitNewHead("a1");
         await emitNewHead("a2"); // first confirmation
         await emitNewHead("a3");
         await emitNewHead("a4");
@@ -180,9 +181,10 @@ describe("ConfirmationObserver", () => {
     });
 
     it("waitForFirstConfirmationOrBlockThreshold resolves when the transaction is mined", async () => {
+        await emitNewHead("a1");
+
         const p = new PromiseSpy(confirmationObserver.waitForFirstConfirmationOrBlockThreshold(txHash, 4));
 
-        await emitNewHead("a1");
         await Promise.resolve(); // flush promises
 
         expect(p.settled, "Did not settle too early").to.be.false;

--- a/test/src/blockMonitor/reorgDetector.test.ts
+++ b/test/src/blockMonitor/reorgDetector.test.ts
@@ -201,7 +201,7 @@ class ReorgMocks {
         const store = new ReorgHeightListenerStore();
         const blockCache = new BlockCache(maxDepth);
         const blockProcessor: BlockProcessor = new BlockProcessor(provider, blockCache);
-        const reorgDetector = new ReorgDetector(provider, blockProcessor, blockCache, store);
+        const reorgDetector = new ReorgDetector(provider, blockProcessor, store);
         await blockProcessor.start();
         await reorgDetector.start();
         return { blockCache, blockProcessor, reorgDetector, provider, store };

--- a/test/src/endToEnd.test.ts
+++ b/test/src/endToEnd.test.ts
@@ -76,14 +76,14 @@ describe("End to end", () => {
 
         const blockCache = new BlockCache(200);
         const blockProcessor = new BlockProcessor(provider, blockCache);
-        const reorgDetector = new ReorgDetector(provider, blockProcessor, blockCache, new ReorgHeightListenerStore());
+        const reorgDetector = new ReorgDetector(provider, blockProcessor, new ReorgHeightListenerStore());
         await blockProcessor.start();
         await reorgDetector.start();
 
         // 2. pass this appointment to the watcher
         const blockTimeoutDetector = new BlockTimeoutDetector(blockProcessor, 120 * 1000);
         await blockTimeoutDetector.start();
-        const confirmationObserver = new ConfirmationObserver(blockCache, blockProcessor);
+        const confirmationObserver = new ConfirmationObserver(blockProcessor);
         await confirmationObserver.start();
         const responderManager = new EthereumResponderManager(
             provider.getSigner(pisaAccount),

--- a/test/src/responder.test.ts
+++ b/test/src/responder.test.ts
@@ -173,7 +173,7 @@ describe("EthereumDedicatedResponder", () => {
 
         blockTimeoutDetector = new BlockTimeoutDetector(blockProcessor, 120 * 1000);
         await blockTimeoutDetector.start();
-        confirmationObserver = new ConfirmationObserver(blockCache, blockProcessor);
+        confirmationObserver = new ConfirmationObserver(blockProcessor);
         await confirmationObserver.start();
 
         // Set up the accounts
@@ -488,7 +488,7 @@ describe("EthereumTransactionMiner", async () => {
         await blockProcessor.start();
         blockTimeoutDetector = new BlockTimeoutDetector(blockProcessor, 120 * 1000);
         await blockTimeoutDetector.start();
-        confirmationObserver = new ConfirmationObserver(blockCache, blockProcessor);
+        confirmationObserver = new ConfirmationObserver(blockProcessor);
         await confirmationObserver.start();
         accounts = await provider.listAccounts();
         account0Signer = provider.getSigner(accounts[0]);

--- a/test/src/utils/index.test.ts
+++ b/test/src/utils/index.test.ts
@@ -8,18 +8,23 @@ describe("waitForEvent", async () => {
         const eventEmitter = new EventEmitter();
         const promise = waitForEvent(eventEmitter, "event");
 
+        const resolveArgs = [42, "test"]; // the arguments passed to the eventHandler
+
         let resolved = false;
-        promise.then(() => {
+        promise.then(args => {
             resolved = true;
+            return args;
         });
 
         await wait(20);
 
         expect(resolved, "did not resolve prematurely").to.be.false;
 
-        eventEmitter.emit("event");
+        eventEmitter.emit("event", ...resolveArgs);
 
-        return promise;
+        const result = await promise;
+
+        expect(result).to.deep.equal(resolveArgs);
     });
 
     it("does not resolve when a different event is emitted", async () => {

--- a/test/src/watcher/watcher.test.ts
+++ b/test/src/watcher/watcher.test.ts
@@ -254,7 +254,7 @@ describe("Watcher", () => {
     it("observe does nothing during a reorg", async () => {
         const blockCache = new BlockCache(200);
         const blockProcessor = new BlockProcessor(provider, blockCache);
-        const reorgDetect = new ReorgDetector(provider, blockProcessor, blockCache, new ReorgHeightListenerStore());
+        const reorgDetect = new ReorgDetector(provider, blockProcessor, new ReorgHeightListenerStore());
         const spiedReorgDetect = spy(reorgDetect);
         const watcher = new Watcher(responderInstance, reorgDetect, appointmentSubscriber, storeInstanceThrow);
         await watcher.start();


### PR DESCRIPTION
Changes in this PR:
- Split the BlockCache from its read-only interface (ReadOnlyBlockCache)
- Made the read-only view of the BlockCache accessible as a member of BlockProcessor
- The blockProcessor now downloads the last block from the provider, so that blockProcessor.head is never null after successfully running start()
- Incidentally, generalized waitForEvent from /utils in order to work also with classes that are not strictly an EventEmitter like the BaseProvider; moreover, it now resolves to the array of arguments passed to the event.