### PR TITLE
Consolidation of reorg detector, block processor and block cache

### DIFF
--- a/src/blockMonitor/blockCache.ts
+++ b/src/blockMonitor/blockCache.ts
@@ -228,10 +228,8 @@ export class BlockCache implements ReadOnlyBlockCache {
         const result = this.findAncestor(blockHash, block => !this.hasBlock(block.parentHash));
 
         if (!result) {
-            // This should never happen
-            throw new ApplicationError(
-                `An error occurred while searching the oldest ancestor in cache. This is a bug.`
-            );
+            // This can never happen, since blockHash already satisfies the predicate in findAncestor
+            throw new ApplicationError("An error occurred while searching for the oldest ancestor in cache.");
         }
 
         return result;

--- a/src/blockMonitor/blockCache.ts
+++ b/src/blockMonitor/blockCache.ts
@@ -230,7 +230,7 @@ export class BlockCache implements ReadOnlyBlockCache {
         if (!result) {
             // This should never happen
             throw new ApplicationError(
-                `An error occurred while searching the oldest block in cache after a catastrophic reorg. This is a bug.`
+                `An error occurred while searching the oldest ancestor in cache. This is a bug.`
             );
         }
 

--- a/src/blockMonitor/blockProcessor.ts
+++ b/src/blockMonitor/blockProcessor.ts
@@ -10,11 +10,11 @@ import { IBlockStub } from "./blockStub";
  * the `blockCache` with the new block and its ancestors.
  */
 export class BlockProcessor extends StartStopService {
-    // keeps track of the last block hash received, in order to correctly emit NEW_HEAD_EVENT
-    private lastBlockHashReceived: string;
+    // keeps track of the last block hash received, in order to correctly emit NEW_HEAD_EVENT; null on startup
+    private lastBlockHashReceived: string | null;
 
     // keeps track of the latest known head received
-    private headHash: string;
+    private headHash: string | null = null;
 
     private mBlockCache: BlockCache;
 
@@ -26,25 +26,37 @@ export class BlockProcessor extends StartStopService {
     }
 
     /**
+     * Event emitted when a new block is mined and has been added to the BlockCache.
+     * It is not guaranteed that no block is skipped, especially in case of reorgs.
+     * Emits the block height and the block hash.
+     */
+    public static readonly NEW_HEAD_EVENT = "new_head";
+
+    /**
+     * Event emitted when a new block is mined that does not seem to be part of the chain the current head is part of.
+     * It is emitted before the corresponding NEW_HEAD_EVENT.
+     * Emits the hash of the common ancestor block (or null if the reorg is deeper than maxDepth), the hash of the current new head,
+     * and the hash of the previous head block.
+     */
+    public static readonly REORG_EVENT = "reorg";
+
+    /**
      * Returns the IBlockStub of the latest known head block.
      *
      * @throws ApplicationError if the block is not found in the cache. This should never happen, unless
      *         `head` is read before the service is started.
      */
     public get head(): IBlockStub {
+        if (this.headHash === null) {
+            throw new ApplicationError("head used before the BlockProcessor is initialized");
+        }
+
         const blockStub = this.blockCache.getBlockStub(this.headHash);
         if (!blockStub) {
             throw new ApplicationError(`Head block ${this.headHash} not found in the BlockCache, but should be there`);
         }
         return blockStub;
     }
-
-    /**
-     * Event emitted when a new block is mined and has been added to the BlockCache.
-     * It is not guaranteed that no block is skipped, especially in case of reorgs.
-     * Emits the block height and the block hash.
-     */
-    public static readonly NEW_HEAD_EVENT = "new_head";
 
     constructor(private provider: ethers.providers.BaseProvider, blockCache: BlockCache) {
         super("block-processor");
@@ -56,7 +68,11 @@ export class BlockProcessor extends StartStopService {
 
     protected async startInternal(): Promise<void> {
         // Make sure the current head block is processed
-        const initialBlockNumber = await this.provider.getBlockNumber();
+        let initialBlockNumber = await this.provider.getBlockNumber();
+
+        // This should never happen
+        if (initialBlockNumber == null) throw new ApplicationError(`getBlockNumber returned ${initialBlockNumber}`);
+
         await this.processBlockNumber(initialBlockNumber);
 
         this.provider.on("block", this.processBlockNumber);
@@ -64,6 +80,31 @@ export class BlockProcessor extends StartStopService {
 
     protected async stopInternal(): Promise<void> {
         this.provider.removeListener("block", this.processBlockNumber);
+    }
+
+    // update the new headHash if needed, and emit the appropriate events
+    private processNewHead(headBlock: ethers.providers.Block, commonAncestorBlock: IBlockStub | null) {
+        const oldHeadHash = this.headHash; // we need to remember the old head for proper Reorg event handling
+        this.headHash = headBlock.hash;
+
+        if (!this.headHash || this.headHash === this.lastBlockHashReceived) {
+            // Emit the appropriate events, but only if the service is already started
+            if (this.started) {
+                if (
+                    !commonAncestorBlock || // deep reorg, no common ancestor
+                    oldHeadHash !== commonAncestorBlock.hash // normal reorg
+                ) {
+                    this.emit(
+                        BlockProcessor.REORG_EVENT,
+                        commonAncestorBlock && commonAncestorBlock.hash,
+                        this.headHash,
+                        oldHeadHash
+                    );
+                }
+
+                this.emit(BlockProcessor.NEW_HEAD_EVENT, headBlock.number, headBlock.hash);
+            }
+        }
     }
 
     // Processes a new block, adding it to the cache and emitting the appropriate events
@@ -82,18 +123,19 @@ export class BlockProcessor extends StartStopService {
                 curBlock = await this.provider.getBlock(curBlock.parentHash);
                 blocksToAdd.push(curBlock);
             }
+            blocksToAdd.reverse(); // add blocks from the oldest
+
+            // Last block in cache in the same chain as the new head
+            const commonAncestorBlock = this.blockCache.getBlockStub(blocksToAdd[0].parentHash);
 
             // populate fetched blocks into cache, starting from the deepest
-            for (const block of blocksToAdd.reverse()) {
+            for (const block of blocksToAdd) {
                 this.mBlockCache.addBlock(block);
             }
 
-            // is the observed block still the last block received?
-            if (this.lastBlockHashReceived === observedBlock.hash) {
-                this.headHash = observedBlock.hash;
-
-                // Emit a NEW_HEAD_EVENT, but only if the service is already started
-                if (this.started) this.emit(BlockProcessor.NEW_HEAD_EVENT, observedBlock.number, observedBlock.hash);
+            // is the observed block still the last block received (or the first block during startup)?
+            if (!this.lastBlockHashReceived || this.lastBlockHashReceived === observedBlock.hash) {
+                this.processNewHead(observedBlock, commonAncestorBlock);
             }
         } catch (doh) {
             const error = doh as Error;

--- a/src/blockMonitor/blockProcessor.ts
+++ b/src/blockMonitor/blockProcessor.ts
@@ -47,8 +47,8 @@ export class BlockProcessor extends StartStopService {
      *         `head` is read before the service is started.
      */
     public get head(): IBlockStub {
-        if (this.headHash === null) {
-            throw new ApplicationError("head used before the BlockProcessor is initialized");
+        if (this.headHash == null) {
+            throw new ApplicationError("head used before the BlockProcessor is initialized.");
         }
 
         const blockStub = this.blockCache.getBlockStub(this.headHash);

--- a/src/blockMonitor/blockProcessor.ts
+++ b/src/blockMonitor/blockProcessor.ts
@@ -68,7 +68,7 @@ export class BlockProcessor extends StartStopService {
 
     protected async startInternal(): Promise<void> {
         // Make sure the current head block is processed
-        let initialBlockNumber = await this.provider.getBlockNumber();
+        const initialBlockNumber = await this.provider.getBlockNumber();
 
         // This should never happen
         if (initialBlockNumber == null) throw new ApplicationError(`getBlockNumber returned ${initialBlockNumber}`);

--- a/src/blockMonitor/blockProcessor.ts
+++ b/src/blockMonitor/blockProcessor.ts
@@ -70,9 +70,6 @@ export class BlockProcessor extends StartStopService {
         // Make sure the current head block is processed
         const initialBlockNumber = await this.provider.getBlockNumber();
 
-        // This should never happen
-        if (initialBlockNumber == null) throw new ApplicationError(`getBlockNumber returned ${initialBlockNumber}`);
-
         await this.processBlockNumber(initialBlockNumber);
 
         this.provider.on("block", this.processBlockNumber);
@@ -112,9 +109,6 @@ export class BlockProcessor extends StartStopService {
         try {
             const observedBlock = await this.provider.getBlock(blockNumber);
 
-            if (!observedBlock.hash) {
-                console.log(observedBlock);
-            }
             this.lastBlockHashReceived = observedBlock.hash;
 
             const blocksToAdd = [observedBlock]; // blocks to add, in reverse order

--- a/src/blockMonitor/blockProcessor.ts
+++ b/src/blockMonitor/blockProcessor.ts
@@ -94,16 +94,12 @@ export class BlockProcessor extends StartStopService {
 
         // Emit the appropriate events, but only if the service is already started
         if (this.isBlockHashLastReceived(this.headHash) && this.started) {
-            if (
-                !commonAncestorBlock || // deep reorg, no common ancestor
-                oldHeadHash !== commonAncestorBlock.hash // normal reorg
-            ) {
-                this.emit(
-                    BlockProcessor.REORG_EVENT,
-                    commonAncestorBlock && commonAncestorBlock.hash,
-                    this.headHash,
-                    oldHeadHash
-                );
+            if (!commonAncestorBlock) {
+                // reorg beyond the depth of the cache; no common ancestor found
+                this.emit(BlockProcessor.REORG_EVENT, null, this.headHash, oldHeadHash);
+            } else if (oldHeadHash !== commonAncestorBlock.hash) {
+                // reorg with a known common ancestor in cache
+                this.emit(BlockProcessor.REORG_EVENT, commonAncestorBlock.hash, this.headHash, oldHeadHash);
             }
 
             this.emit(BlockProcessor.NEW_HEAD_EVENT, headBlock.number, headBlock.hash);

--- a/src/blockMonitor/index.ts
+++ b/src/blockMonitor/index.ts
@@ -1,7 +1,7 @@
 export { BlockStubChain, IBlockStub } from "./blockStub";
 export { ReadOnlyBlockCache, BlockCache } from "./blockCache";
 export { BlockProcessor } from "./blockProcessor";
-export { ReorgDetector } from "./reorgDetector";
+export { ReorgEmitter } from "./reorgEmitter";
 export { ConfirmationObserver } from "./confirmationObserver";
 export { BlockTimeoutDetector } from "./blockTimeoutDetector";
 export { ReorgHeightListenerStore } from "./reorgHeightListener";

--- a/src/blockMonitor/reorgEmitter.ts
+++ b/src/blockMonitor/reorgEmitter.ts
@@ -11,7 +11,7 @@ import { Lock } from "../utils/lock";
  * Emits appropriate events when reorgs are observed, and resets the provider to the common ancestor (whenever possible)
  * so that appropriate block events are emitted.
  */
-export class ReorgDetector extends StartStopService {
+export class ReorgEmitter extends StartStopService {
     private headBlock: IBlockStub;
 
     private lock = new Lock();
@@ -95,7 +95,7 @@ export class ReorgDetector extends StartStopService {
             if (commonAncestorHash === null) {
                 // if we couldn't find a common ancestor the reorg must be too deep
                 const newHeadBlock = this.blockProcessor.blockCache.getBlockStub(newHeadHash)!;
-                this.emit(ReorgDetector.REORG_BEYOND_DEPTH_EVENT, this.headBlock, newHeadBlock);
+                this.emit(ReorgEmitter.REORG_BEYOND_DEPTH_EVENT, this.headBlock, newHeadBlock);
 
                 // find the oldest ancestor of the new head which is still in cache
                 const oldestAncestor = this.blockProcessor.blockCache.getOldestAncestorInCache(newHeadHash);
@@ -131,7 +131,7 @@ export class ReorgDetector extends StartStopService {
         // processing in the meantime
 
         this.provider.polling = false;
-        this.emit(ReorgDetector.REORG_START_EVENT, newHead.number);
+        this.emit(ReorgEmitter.REORG_START_EVENT, newHead.number);
 
         this.setNewHead(newHead.hash);
 
@@ -145,7 +145,7 @@ export class ReorgDetector extends StartStopService {
         this.provider.resetEventsBlock(newHead.number + 1);
 
         // and emit the end reorg event
-        this.emit(ReorgDetector.REORG_END_EVENT, newHead.number);
+        this.emit(ReorgEmitter.REORG_END_EVENT, newHead.number);
         this.provider.polling = true;
     }
 
@@ -179,7 +179,7 @@ export class ReorgDetector extends StartStopService {
 
     /**
      * Add a listener for reorg events that reorg the chain to a common ancestor below a certain height. These events are guaranteed
-     * to fire after ReorgDetector.REORG_START_EVENT and before ReorgDetector.REORG_END_EVENT
+     * to fire after ReorgEmitter.REORG_START_EVENT and before ReorgEmitter.REORG_END_EVENT
      * @param listener This listener will not be present in the listeners() or listenerCount() properties as it
      * can be an async callback, but we must await for it's completion here before emitting synchronous callbacks. So
      * it must be emitted in a different way.

--- a/src/service.ts
+++ b/src/service.ts
@@ -29,7 +29,7 @@ import {
 } from "./blockMonitor";
 import { LevelUp } from "levelup";
 import encodingDown from "encoding-down";
-import { ReorgDetector } from "./blockMonitor/reorgDetector";
+import { ReorgEmitter } from "./blockMonitor/reorgEmitter";
 
 /**
  * Hosts a PISA service at the endpoint.
@@ -37,7 +37,7 @@ import { ReorgDetector } from "./blockMonitor/reorgDetector";
 export class PisaService extends StartStopService {
     private readonly server: Server;
     private readonly garbageCollector: AppointmentStoreGarbageCollector;
-    private readonly reorgDetector: ReorgDetector;
+    private readonly reorgEmitter: ReorgEmitter;
     private readonly blockProcessor: BlockProcessor;
     private readonly blockTimeoutDetector: BlockTimeoutDetector;
     private readonly confirmationObserver: ConfirmationObserver;
@@ -73,7 +73,7 @@ export class PisaService extends StartStopService {
         // start reorg detector and block monitor
         const blockCache = new BlockCache(200);
         this.blockProcessor = new BlockProcessor(delayedProvider, blockCache);
-        this.reorgDetector = new ReorgDetector(delayedProvider, this.blockProcessor, new ReorgHeightListenerStore());
+        this.reorgEmitter = new ReorgEmitter(delayedProvider, this.blockProcessor, new ReorgHeightListenerStore());
 
         // dependencies
         this.appointmentStore = new AppointmentStore(
@@ -90,7 +90,7 @@ export class PisaService extends StartStopService {
         const appointmentSubscriber = new AppointmentSubscriber(delayedProvider);
         this.watcher = new Watcher(
             this.ethereumResponderManager,
-            this.reorgDetector,
+            this.reorgEmitter,
             appointmentSubscriber,
             this.appointmentStore
         );
@@ -118,7 +118,7 @@ export class PisaService extends StartStopService {
 
     protected async startInternal() {
         await this.blockProcessor.start();
-        await this.reorgDetector.start();
+        await this.reorgEmitter.start();
         await this.blockTimeoutDetector.start();
         await this.confirmationObserver.start();
         await this.garbageCollector.start();
@@ -133,7 +133,7 @@ export class PisaService extends StartStopService {
         await this.garbageCollector.stop();
         await this.confirmationObserver.stop();
         await this.blockTimeoutDetector.stop();
-        await this.reorgDetector.stop();
+        await this.reorgEmitter.stop();
         await this.blockProcessor.stop();
         this.server.close(error => {
             if (error) this.logger.error(error.stack!);

--- a/src/watcher/watcher.ts
+++ b/src/watcher/watcher.ts
@@ -3,7 +3,7 @@ import { inspect } from "util";
 import { IEthereumAppointment, StartStopService } from "../dataEntities";
 import { ConfigurationError } from "../dataEntities/errors";
 import { EthereumResponderManager } from "../responder";
-import { ReorgDetector } from "../blockMonitor/reorgDetector";
+import { ReorgEmitter } from "../blockMonitor/reorgEmitter";
 import { AppointmentSubscriber } from "./appointmentSubscriber";
 import { AppointmentStore } from "./store";
 
@@ -20,7 +20,7 @@ export class Watcher extends StartStopService {
      */
     constructor(
         private readonly responder: EthereumResponderManager,
-        private readonly reorgDetector: ReorgDetector,
+        private readonly reorgEmitter: ReorgEmitter,
         private readonly appointmentSubscriber: AppointmentSubscriber,
         private readonly store: AppointmentStore
     ) {
@@ -36,8 +36,8 @@ export class Watcher extends StartStopService {
         this.reorgInProgress = false;
     }
     protected async startInternal() {
-        this.reorgDetector.on(ReorgDetector.REORG_START_EVENT, this.startReorg);
-        this.reorgDetector.on(ReorgDetector.REORG_END_EVENT, this.endReorg);
+        this.reorgEmitter.on(ReorgEmitter.REORG_START_EVENT, this.startReorg);
+        this.reorgEmitter.on(ReorgEmitter.REORG_END_EVENT, this.endReorg);
 
         // add any existing appointments in the store to the subscriber
         for (const appointment of this.store.getAll()) {
@@ -47,8 +47,8 @@ export class Watcher extends StartStopService {
         }
     }
     protected async stopInternal() {
-        this.reorgDetector.removeListener(ReorgDetector.REORG_START_EVENT, this.startReorg);
-        this.reorgDetector.removeListener(ReorgDetector.REORG_END_EVENT, this.endReorg);
+        this.reorgEmitter.removeListener(ReorgEmitter.REORG_START_EVENT, this.startReorg);
+        this.reorgEmitter.removeListener(ReorgEmitter.REORG_END_EVENT, this.endReorg);
     }
 
     // there are three separate processes that can run concurrently as part of the watcher
@@ -139,7 +139,7 @@ export class Watcher extends StartStopService {
             this.responder.respond(appointment);
 
             // register a reorg event
-            this.reorgDetector.addReorgHeightListener(event.blockNumber!, async () => {
+            this.reorgEmitter.addReorgHeightListener(event.blockNumber!, async () => {
                 await this.addAppointment(appointment);
             });
 

--- a/test/src/blockMonitor/blockProcessor.test.ts
+++ b/test/src/blockMonitor/blockProcessor.test.ts
@@ -86,6 +86,9 @@ describe("BlockProcessor", () => {
             eventEmitter.removeAllListeners(arg0)
         );
 
+        // We initially return 0 as the current block number
+        when(mockProvider.getBlockNumber()).thenResolve(0);
+
         provider = instance(mockProvider);
     });
 

--- a/test/src/endToEnd.test.ts
+++ b/test/src/endToEnd.test.ts
@@ -17,7 +17,7 @@ import {
 } from "../../src/blockMonitor";
 import levelup from "levelup";
 import MemDown from "memdown";
-import { ReorgDetector } from "../../src/blockMonitor/reorgDetector";
+import { ReorgEmitter } from "../../src/blockMonitor/reorgEmitter";
 const ganache = Ganache.provider({
     mnemonic: "myth like bonus scare over problem client lizard pioneer submit female collect"
 });
@@ -76,9 +76,9 @@ describe("End to end", () => {
 
         const blockCache = new BlockCache(200);
         const blockProcessor = new BlockProcessor(provider, blockCache);
-        const reorgDetector = new ReorgDetector(provider, blockProcessor, new ReorgHeightListenerStore());
+        const reorgEmitter = new ReorgEmitter(provider, blockProcessor, new ReorgHeightListenerStore());
         await blockProcessor.start();
-        await reorgDetector.start();
+        await reorgEmitter.start();
 
         // 2. pass this appointment to the watcher
         const blockTimeoutDetector = new BlockTimeoutDetector(blockProcessor, 120 * 1000);
@@ -97,7 +97,7 @@ describe("End to end", () => {
             new Map([[ChannelType.Kitsune, (obj: any) => new KitsuneAppointment(obj)]])
         );
         await store.start();
-        const watcher = new Watcher(responderManager, reorgDetector, new AppointmentSubscriber(provider), store);
+        const watcher = new Watcher(responderManager, reorgEmitter, new AppointmentSubscriber(provider), store);
         await watcher.start();
         const player0Contract = channelContract.connect(provider.getSigner(player0));
 
@@ -111,7 +111,7 @@ describe("End to end", () => {
         await store.stop();
         await confirmationObserver.stop();
         await blockTimeoutDetector.stop();
-        await reorgDetector.stop();
+        await reorgEmitter.stop();
         await blockProcessor.stop();
         await db.close();
         await wait(2000);


### PR DESCRIPTION
- Removed all usages of BlockStubChain, just referring to IBlockStubs by hash
- Added a REORG_EVENT to BlockProcessor, refactored ReorgDetector to use it instead
- ReorgDetector (renamed to ReorgEmitter) now only bothers with signaling the reorg start/end events, emitting the height listeners and resetting the provider.
- Incidentally, minor improvements to the BlockCache.

Will add separate tickets for:
- ReorgEmitter might be made redundant by the other mechanisms for handling reorgs we are developing; if not, uinit tests need some love, they are a bit complicated, and I made things worse due to multiple refactoring.
- BlockProcessor has now two events, but there are no tests for their behavior and interaction (e.g. order of firing)