### PR TITLE
Refactoring of the BlockCache and BlockProcessor

### DIFF
--- a/src/blockMonitor/blockCache.ts
+++ b/src/blockMonitor/blockCache.ts
@@ -1,5 +1,5 @@
 import { ApplicationError, ArgumentError } from "../dataEntities";
-import { IBlockStub, HasTxHashes } from "../dataEntities/block";
+import { IBlockStub, Transactions } from "../dataEntities/block";
 
 /**
  * This interface represents the read-only view of a BlockCache.
@@ -233,7 +233,7 @@ export class BlockCache<T extends IBlockStub> implements ReadOnlyBlockCache<T> {
  * @param txHash
  * @throws `ArgumentError` if the block with hash `headHash` is not in the cache.
  */
-export function getConfirmations<T extends IBlockStub & HasTxHashes>(
+export function getConfirmations<T extends IBlockStub & Transactions>(
     cache: ReadOnlyBlockCache<T>,
     headHash: string,
     txHash: string

--- a/src/blockMonitor/blockProcessor.ts
+++ b/src/blockMonitor/blockProcessor.ts
@@ -2,13 +2,13 @@ import { ethers } from "ethers";
 import { StartStopService, ApplicationError } from "../dataEntities";
 import { ReadOnlyBlockCache, BlockCache } from "./blockCache";
 import { IBlockStub } from "../dataEntities";
-import { Block, HasTxHashes } from "../dataEntities/block";
+import { Block, Transactions } from "../dataEntities/block";
 
 type BlockFactory<T> = (provider: ethers.providers.Provider) => (blockNumberOrHash: number | string) => Promise<T>;
 
-export const minimalBlockFactory = (provider: ethers.providers.Provider) => async (
+export const blockStubAndTxFactory = (provider: ethers.providers.Provider) => async (
     blockNumberOrHash: string | number
-): Promise<IBlockStub & HasTxHashes> => {
+): Promise<IBlockStub & Transactions> => {
     const block = await provider.getBlock(blockNumberOrHash);
     return {
         hash: block.hash,
@@ -18,13 +18,15 @@ export const minimalBlockFactory = (provider: ethers.providers.Provider) => asyn
     };
 };
 
-export const defaultBlockFactory = (provider: ethers.providers.Provider) => async (
+export const blockFactory = (provider: ethers.providers.Provider) => async (
     blockNumberOrHash: string | number
 ): Promise<Block> => {
     const block = await provider.getBlock(blockNumberOrHash);
+
+    // We could filter out the logs that we are not interesting in order to save space
+    // (e.g.: only keep the logs from the DataRegistry).
     const logs = await provider.getLogs({
         blockHash: block.hash
-        // TODO: filter interesting logs, instead of taking everything
     });
 
     return {

--- a/src/blockMonitor/blockProcessor.ts
+++ b/src/blockMonitor/blockProcessor.ts
@@ -1,7 +1,40 @@
 import { ethers } from "ethers";
 import { StartStopService, ApplicationError } from "../dataEntities";
 import { ReadOnlyBlockCache, BlockCache } from "./blockCache";
-import { IBlockStub } from "./blockStub";
+import { IBlockStub } from "../dataEntities";
+import { Block, HasTxHashes } from "../dataEntities/block";
+
+type BlockFactory<T> = (provider: ethers.providers.Provider) => (blockNumberOrHash: number | string) => Promise<T>;
+
+export const minimalBlockFactory = (provider: ethers.providers.Provider) => async (
+    blockNumberOrHash: string | number
+): Promise<IBlockStub & HasTxHashes> => {
+    const block = await provider.getBlock(blockNumberOrHash);
+    return {
+        hash: block.hash,
+        number: block.number,
+        parentHash: block.parentHash,
+        transactions: block.transactions
+    };
+};
+
+export const defaultBlockFactory = (provider: ethers.providers.Provider) => async (
+    blockNumberOrHash: string | number
+): Promise<Block> => {
+    const block = await provider.getBlock(blockNumberOrHash);
+    const logs = await provider.getLogs({
+        blockHash: block.hash
+        // TODO: filter interesting logs, instead of taking everything
+    });
+
+    return {
+        hash: block.hash,
+        number: block.number,
+        parentHash: block.parentHash,
+        transactions: block.transactions,
+        logs
+    };
+};
 
 /**
  * Listens to the provider for new blocks, and updates `blockCache` with all the blocks, making sure that each block
@@ -9,19 +42,21 @@ import { IBlockStub } from "./blockStub";
  * It generates a `NEW_HEAD_EVENT` every time a new block is received by the provider, but only after populating
  * the `blockCache` with the new block and its ancestors.
  */
-export class BlockProcessor extends StartStopService {
+export class BlockProcessor<T extends IBlockStub> extends StartStopService {
     // keeps track of the last block hash received, in order to correctly emit NEW_HEAD_EVENT; null on startup
     private lastBlockHashReceived: string | null;
 
     // keeps track of the latest known head received
     private headHash: string | null = null;
 
-    private mBlockCache: BlockCache;
+    private mBlockCache: BlockCache<T>;
+
+    private getBlock: (blockNumberOrHash: string | number) => Promise<T>;
 
     /**
      * Returns the ReadOnlyBlockCache associated to this BlockProcessor.
      */
-    public get blockCache(): ReadOnlyBlockCache {
+    public get blockCache(): ReadOnlyBlockCache<T> {
         return this.mBlockCache;
     }
 
@@ -41,12 +76,12 @@ export class BlockProcessor extends StartStopService {
     public static readonly REORG_EVENT = "reorg";
 
     /**
-     * Returns the IBlockStub of the latest known head block.
+     * Returns the latest known head block.
      *
      * @throws ApplicationError if the block is not found in the cache. This should never happen, unless
      *         `head` is read before the service is started.
      */
-    public get head(): IBlockStub {
+    public get head(): T {
         if (this.headHash == null) {
             throw new ApplicationError("head used before the BlockProcessor is initialized.");
         }
@@ -58,9 +93,14 @@ export class BlockProcessor extends StartStopService {
         return blockStub;
     }
 
-    constructor(private provider: ethers.providers.BaseProvider, blockCache: BlockCache) {
+    constructor(
+        private provider: ethers.providers.BaseProvider,
+        blockFactory: BlockFactory<T>,
+        blockCache: BlockCache<T>
+    ) {
         super("block-processor");
 
+        this.getBlock = blockFactory(provider);
         this.mBlockCache = blockCache;
 
         this.processBlockNumber = this.processBlockNumber.bind(this);
@@ -85,7 +125,7 @@ export class BlockProcessor extends StartStopService {
     }
 
     // update the new headHash if needed, and emit the appropriate events
-    private processNewHead(headBlock: ethers.providers.Block, commonAncestorBlock: IBlockStub | null) {
+    private processNewHead(headBlock: T, commonAncestorBlock: T | null) {
         const oldHeadHash = this.headHash; // we need to remember the old head for proper Reorg event handling
         this.headHash = headBlock.hash;
 
@@ -107,7 +147,7 @@ export class BlockProcessor extends StartStopService {
     // It is called for each new block received, but also at startup (during startInternal).
     private async processBlockNumber(blockNumber: number) {
         try {
-            const observedBlock = await this.provider.getBlock(blockNumber);
+            const observedBlock = await this.getBlock(blockNumber);
 
             this.lastBlockHashReceived = observedBlock.hash;
 
@@ -116,7 +156,7 @@ export class BlockProcessor extends StartStopService {
             // fetch ancestors until one is found that can be added
             let curBlock = observedBlock;
             while (!this.blockCache.canAddBlock(curBlock)) {
-                curBlock = await this.provider.getBlock(curBlock.parentHash);
+                curBlock = await this.getBlock(curBlock.parentHash);
                 blocksToAdd.push(curBlock);
             }
             blocksToAdd.reverse(); // add blocks from the oldest

--- a/src/blockMonitor/blockStub.ts
+++ b/src/blockMonitor/blockStub.ts
@@ -1,4 +1,5 @@
 import { ArgumentError } from "../dataEntities";
+import { IBlockStub } from "../dataEntities";
 
 /**
  * A chain of linked block stubs.
@@ -123,10 +124,4 @@ export class BlockStubChain {
             parentHash: this.parentHash
         };
     }
-}
-
-export interface IBlockStub {
-    hash: string;
-    number: number;
-    parentHash: string;
 }

--- a/src/blockMonitor/blockTimeoutDetector.ts
+++ b/src/blockMonitor/blockTimeoutDetector.ts
@@ -16,7 +16,7 @@ export class BlockTimeoutDetector extends StartStopService {
     /**
      * @param timeout The number of milliseconds without a new block before generating
      */
-    constructor(private blockProcessor: BlockProcessor, public readonly timeout: number) {
+    constructor(private blockProcessor: BlockProcessor<any>, public readonly timeout: number) {
         super("block-timeout-detector");
         this.resetNoNewBlockTimeout = this.resetNoNewBlockTimeout.bind(this);
     }

--- a/src/blockMonitor/blockTimeoutDetector.ts
+++ b/src/blockMonitor/blockTimeoutDetector.ts
@@ -1,5 +1,5 @@
 import { BlockProcessor } from "./blockProcessor";
-import { StartStopService } from "../dataEntities";
+import { StartStopService, IBlockStub } from "../dataEntities";
 
 /**
  * Generates events when no new block is observed for too long, possibly signaling a malfunctioning of the provider.
@@ -16,7 +16,7 @@ export class BlockTimeoutDetector extends StartStopService {
     /**
      * @param timeout The number of milliseconds without a new block before generating
      */
-    constructor(private blockProcessor: BlockProcessor<any>, public readonly timeout: number) {
+    constructor(private blockProcessor: BlockProcessor<IBlockStub>, public readonly timeout: number) {
         super("block-timeout-detector");
         this.resetNoNewBlockTimeout = this.resetNoNewBlockTimeout.bind(this);
     }

--- a/src/blockMonitor/confirmationObserver.ts
+++ b/src/blockMonitor/confirmationObserver.ts
@@ -1,7 +1,7 @@
 import { StartStopService, ArgumentError, BlockThresholdReachedError, ReorgError } from "../dataEntities";
 import { BlockProcessor } from "./blockProcessor";
 import { CancellablePromise, cancellablePromiseRace } from "../utils";
-import { HasTxHashes, IBlockStub } from "../dataEntities/block";
+import { Transactions, IBlockStub } from "../dataEntities/block";
 import { getConfirmations } from "./blockCache";
 
 // A TransactionListener fulfills/rejects a promise if possible; returns true on success
@@ -10,10 +10,10 @@ type TransactionListener = (blockNumber: number, blockHash: string) => boolean;
 /**
  * Allows to observe transactions to be notified when they reach a given number of confirmations.
  */
-export class ConfirmationObserver<T extends IBlockStub & HasTxHashes> extends StartStopService {
+export class ConfirmationObserver extends StartStopService {
     private txListeners = new Set<TransactionListener>();
 
-    constructor(private readonly blockProcessor: BlockProcessor<T>) {
+    constructor(private readonly blockProcessor: BlockProcessor<IBlockStub & Transactions>) {
         super("confirmation-observer");
         this.handleNewHead = this.handleNewHead.bind(this);
     }

--- a/src/blockMonitor/confirmationObserver.ts
+++ b/src/blockMonitor/confirmationObserver.ts
@@ -1,6 +1,8 @@
 import { StartStopService, ArgumentError, BlockThresholdReachedError, ReorgError } from "../dataEntities";
 import { BlockProcessor } from "./blockProcessor";
 import { CancellablePromise, cancellablePromiseRace } from "../utils";
+import { HasTxHashes, IBlockStub } from "../dataEntities/block";
+import { getConfirmations } from "./blockCache";
 
 // A TransactionListener fulfills/rejects a promise if possible; returns true on success
 type TransactionListener = (blockNumber: number, blockHash: string) => boolean;
@@ -8,10 +10,10 @@ type TransactionListener = (blockNumber: number, blockHash: string) => boolean;
 /**
  * Allows to observe transactions to be notified when they reach a given number of confirmations.
  */
-export class ConfirmationObserver extends StartStopService {
+export class ConfirmationObserver<T extends IBlockStub & HasTxHashes> extends StartStopService {
     private txListeners = new Set<TransactionListener>();
 
-    constructor(private readonly blockProcessor: BlockProcessor) {
+    constructor(private readonly blockProcessor: BlockProcessor<T>) {
         super("confirmation-observer");
         this.handleNewHead = this.handleNewHead.bind(this);
     }
@@ -33,7 +35,7 @@ export class ConfirmationObserver extends StartStopService {
         }
     }
 
-    private listenForPredicate<T>(predicate: TransactionListener): CancellablePromise<T> {
+    private listenForPredicate(predicate: TransactionListener): CancellablePromise<void> {
         const createResolvingPredicate = (resolve: () => void) => (blockNumber: number, blockHash: string): boolean => {
             const result = predicate(blockNumber, blockHash);
             if (result) resolve();
@@ -66,13 +68,13 @@ export class ConfirmationObserver extends StartStopService {
         }
 
         const headHash = this.blockProcessor.head.hash;
-        if (blockCache.getConfirmations(headHash, txHash) >= nConfirmations) {
+        if (getConfirmations(blockCache, headHash, txHash) >= nConfirmations) {
             // already has enough confirmations, resolve immediately
             return new CancellablePromise(resolve => resolve());
         }
 
         return this.listenForPredicate(
-            (_, blockHash) => blockCache.getConfirmations(blockHash, txHash) >= nConfirmations
+            (_, blockHash) => getConfirmations(blockCache, blockHash, txHash) >= nConfirmations
         );
     }
 
@@ -99,7 +101,7 @@ export class ConfirmationObserver extends StartStopService {
     public waitForConfirmationsToGoToZero(txHash: string) {
         // listen on each block to see if the confirmations for this block go to zero
         return this.listenForPredicate(
-            (_, blockHash) => this.blockProcessor.blockCache.getConfirmations(blockHash, txHash) === 0
+            (_, blockHash) => getConfirmations(this.blockProcessor.blockCache, blockHash, txHash) === 0
         );
     }
 
@@ -108,7 +110,10 @@ export class ConfirmationObserver extends StartStopService {
      * confirmation, but throws a `BlockThresholdReachedError` if  `blockThreshold` new blocks are mined and the
      * transaction is still unconfirmed.
      */
-    public waitForFirstConfirmationOrBlockThreshold(txHash: string, blockThreshold: number): CancellablePromise<{}> {
+    public waitForFirstConfirmationOrBlockThreshold(
+        txHash: string,
+        blockThreshold: number
+    ): CancellablePromise<unknown> {
         const confirmationsPromise = this.waitForConfirmations(txHash, 1);
         const blockThresholdPromise = this.waitForBlocks(blockThreshold);
         const blockThresholdPromiseThrow = blockThresholdPromise.then(() => {

--- a/src/blockMonitor/index.ts
+++ b/src/blockMonitor/index.ts
@@ -1,5 +1,5 @@
-export { BlockStubChain, IBlockStub } from "./blockStub";
-export { ReadOnlyBlockCache, BlockCache } from "./blockCache";
+export { BlockStubChain } from "./blockStub";
+export { ReadOnlyBlockCache, BlockCache, getConfirmations } from "./blockCache";
 export { BlockProcessor } from "./blockProcessor";
 export { ReorgEmitter } from "./reorgEmitter";
 export { ConfirmationObserver } from "./confirmationObserver";

--- a/src/blockMonitor/index.ts
+++ b/src/blockMonitor/index.ts
@@ -1,6 +1,6 @@
 export { BlockStubChain } from "./blockStub";
 export { ReadOnlyBlockCache, BlockCache, getConfirmations } from "./blockCache";
-export { BlockProcessor } from "./blockProcessor";
+export { BlockProcessor, blockStubAndTxFactory, blockFactory } from "./blockProcessor";
 export { ReorgEmitter } from "./reorgEmitter";
 export { ConfirmationObserver } from "./confirmationObserver";
 export { BlockTimeoutDetector } from "./blockTimeoutDetector";

--- a/src/blockMonitor/reorgEmitter.ts
+++ b/src/blockMonitor/reorgEmitter.ts
@@ -1,6 +1,5 @@
 import { ethers } from "ethers";
-import { StartStopService, ApplicationError } from "../dataEntities";
-import { IBlockStub } from "./blockStub";
+import { StartStopService, ApplicationError, IBlockStub } from "../dataEntities";
 import { ReorgHeightListenerStore } from "./reorgHeightListener";
 import { BlockProcessor } from "./blockProcessor";
 import { Lock } from "../utils/lock";
@@ -53,7 +52,7 @@ export class ReorgEmitter extends StartStopService {
      */
     constructor(
         private readonly provider: ethers.providers.BaseProvider,
-        private readonly blockProcessor: BlockProcessor,
+        private readonly blockProcessor: BlockProcessor<IBlockStub>,
         public readonly store: ReorgHeightListenerStore
     ) {
         super("reorg-detector");

--- a/src/dataEntities/block.ts
+++ b/src/dataEntities/block.ts
@@ -6,12 +6,12 @@ export interface IBlockStub {
     parentHash: string;
 }
 
-export interface HasLogs {
-    logs: ethers.providers.Log[]; // TODO: use own type?
+export interface Logs {
+    logs: ethers.providers.Log[];
 }
 
-export interface HasTxHashes {
+export interface Transactions {
     transactions: string[];
 }
 
-export interface Block extends IBlockStub, HasLogs, HasTxHashes {}
+export interface Block extends IBlockStub, Logs, Transactions {}

--- a/src/dataEntities/block.ts
+++ b/src/dataEntities/block.ts
@@ -1,0 +1,17 @@
+import { ethers } from "ethers";
+
+export interface IBlockStub {
+    hash: string;
+    number: number;
+    parentHash: string;
+}
+
+export interface HasLogs {
+    logs: ethers.providers.Log[]; // TODO: use own type?
+}
+
+export interface HasTxHashes {
+    transactions: string[];
+}
+
+export interface Block extends IBlockStub, HasLogs, HasTxHashes {}

--- a/src/dataEntities/index.ts
+++ b/src/dataEntities/index.ts
@@ -19,3 +19,4 @@ export {
     isArrayOfStrings
 } from "./checkAppointment";
 export { StartStopService } from "./startStop";
+export { IBlockStub, HasTxHashes, HasLogs } from "./block";

--- a/src/dataEntities/index.ts
+++ b/src/dataEntities/index.ts
@@ -19,4 +19,4 @@ export {
     isArrayOfStrings
 } from "./checkAppointment";
 export { StartStopService } from "./startStop";
-export { IBlockStub, HasTxHashes, HasLogs } from "./block";
+export { IBlockStub, Transactions, Logs } from "./block";

--- a/src/responder.ts
+++ b/src/responder.ts
@@ -3,7 +3,14 @@ import { ethers } from "ethers";
 import { wait, plural, waitForEvent } from "./utils";
 import { IEthereumAppointment, IEthereumResponseData } from "./dataEntities/appointment";
 import logger from "./logger";
-import { ApplicationError, ArgumentError, BlockThresholdReachedError, BlockTimeoutError } from "./dataEntities";
+import {
+    ApplicationError,
+    ArgumentError,
+    BlockThresholdReachedError,
+    BlockTimeoutError,
+    IBlockStub,
+    HasTxHashes
+} from "./dataEntities";
 import { BlockTimeoutDetector, ConfirmationObserver } from "./blockMonitor";
 
 /**
@@ -179,7 +186,7 @@ export class EthereumTransactionMiner {
     constructor(
         public readonly signer: ethers.Signer,
         private readonly blockTimeoutDetector: BlockTimeoutDetector,
-        private readonly confirmationObserver: ConfirmationObserver,
+        private readonly confirmationObserver: ConfirmationObserver<IBlockStub & HasTxHashes>,
         public readonly confirmationsRequired: number,
         public readonly blocksThresholdForStuckTransaction: number
     ) {
@@ -390,7 +397,7 @@ export class EthereumResponderManager {
     constructor(
         private readonly signer: ethers.Signer,
         private readonly blockTimeoutDetector: BlockTimeoutDetector,
-        private readonly confirmationObserver: ConfirmationObserver
+        private readonly confirmationObserver: ConfirmationObserver<IBlockStub & HasTxHashes>
     ) {
         if (!signer.provider) throw new ArgumentError("The given signer is not connected to a provider");
 

--- a/src/responder.ts
+++ b/src/responder.ts
@@ -9,7 +9,7 @@ import {
     BlockThresholdReachedError,
     BlockTimeoutError,
     IBlockStub,
-    HasTxHashes
+    Transactions
 } from "./dataEntities";
 import { BlockTimeoutDetector, ConfirmationObserver } from "./blockMonitor";
 
@@ -186,7 +186,7 @@ export class EthereumTransactionMiner {
     constructor(
         public readonly signer: ethers.Signer,
         private readonly blockTimeoutDetector: BlockTimeoutDetector,
-        private readonly confirmationObserver: ConfirmationObserver<IBlockStub & HasTxHashes>,
+        private readonly confirmationObserver: ConfirmationObserver,
         public readonly confirmationsRequired: number,
         public readonly blocksThresholdForStuckTransaction: number
     ) {
@@ -397,7 +397,7 @@ export class EthereumResponderManager {
     constructor(
         private readonly signer: ethers.Signer,
         private readonly blockTimeoutDetector: BlockTimeoutDetector,
-        private readonly confirmationObserver: ConfirmationObserver<IBlockStub & HasTxHashes>
+        private readonly confirmationObserver: ConfirmationObserver
     ) {
         if (!signer.provider) throw new ArgumentError("The given signer is not connected to a provider");
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -29,8 +29,7 @@ import {
 } from "./blockMonitor";
 import { LevelUp } from "levelup";
 import encodingDown from "encoding-down";
-import { ReorgEmitter } from "./blockMonitor/reorgEmitter";
-import { defaultBlockFactory } from "./blockMonitor/blockProcessor";
+import { ReorgEmitter, blockFactory } from "./blockMonitor";
 import { Block } from "./dataEntities/block";
 
 /**
@@ -42,7 +41,7 @@ export class PisaService extends StartStopService {
     private readonly reorgEmitter: ReorgEmitter;
     private readonly blockProcessor: BlockProcessor<Block>;
     private readonly blockTimeoutDetector: BlockTimeoutDetector;
-    private readonly confirmationObserver: ConfirmationObserver<Block>;
+    private readonly confirmationObserver: ConfirmationObserver;
     private readonly ethereumResponderManager: EthereumResponderManager;
     private readonly watcher: Watcher;
     private readonly appointmentStore: AppointmentStore;
@@ -74,7 +73,7 @@ export class PisaService extends StartStopService {
 
         // start reorg detector and block monitor
         const blockCache = new BlockCache<Block>(200);
-        this.blockProcessor = new BlockProcessor<Block>(delayedProvider, defaultBlockFactory, blockCache);
+        this.blockProcessor = new BlockProcessor<Block>(delayedProvider, blockFactory, blockCache);
         this.reorgEmitter = new ReorgEmitter(delayedProvider, this.blockProcessor, new ReorgHeightListenerStore());
 
         // dependencies

--- a/src/service.ts
+++ b/src/service.ts
@@ -30,6 +30,8 @@ import {
 import { LevelUp } from "levelup";
 import encodingDown from "encoding-down";
 import { ReorgEmitter } from "./blockMonitor/reorgEmitter";
+import { defaultBlockFactory } from "./blockMonitor/blockProcessor";
+import { Block } from "./dataEntities/block";
 
 /**
  * Hosts a PISA service at the endpoint.
@@ -38,9 +40,9 @@ export class PisaService extends StartStopService {
     private readonly server: Server;
     private readonly garbageCollector: AppointmentStoreGarbageCollector;
     private readonly reorgEmitter: ReorgEmitter;
-    private readonly blockProcessor: BlockProcessor;
+    private readonly blockProcessor: BlockProcessor<Block>;
     private readonly blockTimeoutDetector: BlockTimeoutDetector;
-    private readonly confirmationObserver: ConfirmationObserver;
+    private readonly confirmationObserver: ConfirmationObserver<Block>;
     private readonly ethereumResponderManager: EthereumResponderManager;
     private readonly watcher: Watcher;
     private readonly appointmentStore: AppointmentStore;
@@ -71,8 +73,8 @@ export class PisaService extends StartStopService {
         const configs = [Raiden, Kitsune];
 
         // start reorg detector and block monitor
-        const blockCache = new BlockCache(200);
-        this.blockProcessor = new BlockProcessor(delayedProvider, blockCache);
+        const blockCache = new BlockCache<Block>(200);
+        this.blockProcessor = new BlockProcessor<Block>(delayedProvider, defaultBlockFactory, blockCache);
         this.reorgEmitter = new ReorgEmitter(delayedProvider, this.blockProcessor, new ReorgHeightListenerStore());
 
         // dependencies

--- a/test/src/blockMonitor/blockCache.test.ts
+++ b/test/src/blockMonitor/blockCache.test.ts
@@ -2,7 +2,7 @@ import "mocha";
 import { expect } from "chai";
 import { BlockCache, getConfirmations } from "../../../src/blockMonitor";
 import { ethers } from "ethers";
-import { ArgumentError, IBlockStub, HasTxHashes } from "../../../src/dataEntities";
+import { ArgumentError, IBlockStub, Transactions } from "../../../src/dataEntities";
 
 function generateBlocks(
     nBlocks: number,
@@ -195,7 +195,7 @@ describe("BlockCache", () => {
 describe("getConfirmations", () => {
     const maxDepth = 100;
     it("correctly computes the number of confirmations for a transaction", () => {
-        const bc = new BlockCache<IBlockStub & HasTxHashes>(maxDepth);
+        const bc = new BlockCache<IBlockStub & Transactions>(maxDepth);
         const blocks = generateBlocks(7, 0, "main"); // must be less blocks than maxDepth
         blocks.forEach(block => bc.addBlock(block));
 
@@ -205,7 +205,7 @@ describe("getConfirmations", () => {
     });
 
     it("correctly returns 0 confirmations if transaction is not known", () => {
-        const bc = new BlockCache<IBlockStub & HasTxHashes>(maxDepth);
+        const bc = new BlockCache<IBlockStub & Transactions>(maxDepth);
         const blocks = generateBlocks(128, 0, "main");
         blocks.forEach(block => bc.addBlock(block));
 
@@ -214,7 +214,7 @@ describe("getConfirmations", () => {
     });
 
     it("throws ArgumentError if no block with the given hash is in the BlockCache", () => {
-        const bc = new BlockCache<IBlockStub & HasTxHashes>(maxDepth);
+        const bc = new BlockCache<IBlockStub & Transactions>(maxDepth);
         const blocks = generateBlocks(128, 0, "main");
         blocks.forEach(block => bc.addBlock(block));
 

--- a/test/src/blockMonitor/blockProcessor.test.ts
+++ b/test/src/blockMonitor/blockProcessor.test.ts
@@ -4,9 +4,8 @@ import chaiAsPromised from "chai-as-promised";
 import { ethers } from "ethers";
 import { mock, when, instance, anything } from "ts-mockito";
 import { EventEmitter } from "events";
-import { BlockProcessor, BlockCache } from "../../../src/blockMonitor";
+import { BlockProcessor, BlockCache, blockStubAndTxFactory } from "../../../src/blockMonitor";
 import { IBlockStub } from "../../../src/dataEntities";
-import { minimalBlockFactory } from "../../../src/blockMonitor/blockProcessor";
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
@@ -101,14 +100,14 @@ describe("BlockProcessor", () => {
     it("correctly processes the blockchain head after startup", async () => {
         emitBlockHash("a1");
 
-        blockProcessor = new BlockProcessor(provider, minimalBlockFactory, blockCache);
+        blockProcessor = new BlockProcessor(provider, blockStubAndTxFactory, blockCache);
         await blockProcessor.start();
 
         expect(blockProcessor.head.hash).to.equal("a1");
     });
 
     it("adds the first block received to the cache and emits a new head event", async () => {
-        blockProcessor = new BlockProcessor(provider, minimalBlockFactory, blockCache);
+        blockProcessor = new BlockProcessor(provider, blockStubAndTxFactory, blockCache);
         await blockProcessor.start();
 
         const res = new Promise(resolve => {
@@ -125,7 +124,7 @@ describe("BlockProcessor", () => {
     });
 
     it("adds to the blockCache all ancestors until a known block", async () => {
-        blockProcessor = new BlockProcessor(provider, minimalBlockFactory, blockCache);
+        blockProcessor = new BlockProcessor(provider, blockStubAndTxFactory, blockCache);
         await blockProcessor.start();
 
         emitBlockHash("a1");
@@ -138,7 +137,7 @@ describe("BlockProcessor", () => {
     });
 
     it("adds both chain until the common ancestor if there is a fork", async () => {
-        blockProcessor = new BlockProcessor(provider, minimalBlockFactory, blockCache);
+        blockProcessor = new BlockProcessor(provider, blockStubAndTxFactory, blockCache);
         await blockProcessor.start();
 
         emitBlockHash("a1");
@@ -154,7 +153,7 @@ describe("BlockProcessor", () => {
     });
 
     it("adds both chain until the common ancestor if there is a fork", async () => {
-        blockProcessor = new BlockProcessor(provider, minimalBlockFactory, blockCache);
+        blockProcessor = new BlockProcessor(provider, blockStubAndTxFactory, blockCache);
         await blockProcessor.start();
 
         emitBlockHash("a1");

--- a/test/src/blockMonitor/blockProcessor.test.ts
+++ b/test/src/blockMonitor/blockProcessor.test.ts
@@ -1,10 +1,12 @@
 import "mocha";
 import * as chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import { BlockProcessor, BlockCache, IBlockStub } from "../../../src/blockMonitor";
 import { ethers } from "ethers";
 import { mock, when, instance, anything } from "ts-mockito";
 import { EventEmitter } from "events";
+import { BlockProcessor, BlockCache } from "../../../src/blockMonitor";
+import { IBlockStub } from "../../../src/dataEntities";
+import { minimalBlockFactory } from "../../../src/blockMonitor/blockProcessor";
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
@@ -44,8 +46,8 @@ const blocksByHash: { [key: string]: IBlockStub } = {
 
 describe("BlockProcessor", () => {
     const maxDepth = 5;
-    let blockCache: BlockCache;
-    let blockProcessor: BlockProcessor;
+    let blockCache: BlockCache<IBlockStub>;
+    let blockProcessor: BlockProcessor<IBlockStub>;
     let mockProvider: ethers.providers.BaseProvider;
     let provider: ethers.providers.BaseProvider;
 
@@ -99,14 +101,14 @@ describe("BlockProcessor", () => {
     it("correctly processes the blockchain head after startup", async () => {
         emitBlockHash("a1");
 
-        blockProcessor = new BlockProcessor(provider, blockCache);
+        blockProcessor = new BlockProcessor(provider, minimalBlockFactory, blockCache);
         await blockProcessor.start();
 
         expect(blockProcessor.head.hash).to.equal("a1");
     });
 
     it("adds the first block received to the cache and emits a new head event", async () => {
-        blockProcessor = new BlockProcessor(provider, blockCache);
+        blockProcessor = new BlockProcessor(provider, minimalBlockFactory, blockCache);
         await blockProcessor.start();
 
         const res = new Promise(resolve => {
@@ -123,7 +125,7 @@ describe("BlockProcessor", () => {
     });
 
     it("adds to the blockCache all ancestors until a known block", async () => {
-        blockProcessor = new BlockProcessor(provider, blockCache);
+        blockProcessor = new BlockProcessor(provider, minimalBlockFactory, blockCache);
         await blockProcessor.start();
 
         emitBlockHash("a1");
@@ -136,7 +138,7 @@ describe("BlockProcessor", () => {
     });
 
     it("adds both chain until the common ancestor if there is a fork", async () => {
-        blockProcessor = new BlockProcessor(provider, blockCache);
+        blockProcessor = new BlockProcessor(provider, minimalBlockFactory, blockCache);
         await blockProcessor.start();
 
         emitBlockHash("a1");
@@ -152,7 +154,7 @@ describe("BlockProcessor", () => {
     });
 
     it("adds both chain until the common ancestor if there is a fork", async () => {
-        blockProcessor = new BlockProcessor(provider, blockCache);
+        blockProcessor = new BlockProcessor(provider, minimalBlockFactory, blockCache);
         await blockProcessor.start();
 
         emitBlockHash("a1");

--- a/test/src/blockMonitor/blockTimeoutDetector.test.ts
+++ b/test/src/blockMonitor/blockTimeoutDetector.test.ts
@@ -4,13 +4,14 @@ import chaiAsPromised from "chai-as-promised";
 import lolex from "lolex";
 import { BlockTimeoutDetector, BlockProcessor } from "../../../src/blockMonitor";
 import { EventEmitter } from "events";
+import { IBlockStub } from "../../../src/dataEntities";
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
 
 describe("BlockTimeoutDetector", () => {
     const timeout = 120 * 1000;
-    let mockBlockProcessor: BlockProcessor;
+    let mockBlockProcessor: BlockProcessor<IBlockStub>;
     let clock: lolex.InstalledClock;
     let blockTimeoutDetector: BlockTimeoutDetector;
 
@@ -18,7 +19,7 @@ describe("BlockTimeoutDetector", () => {
         clock = lolex.install();
 
         const eventEmitter = new EventEmitter();
-        mockBlockProcessor = eventEmitter as BlockProcessor; // we just need the mock to emit events
+        mockBlockProcessor = eventEmitter as BlockProcessor<IBlockStub>; // we just need the mock to emit events
 
         blockTimeoutDetector = new BlockTimeoutDetector(mockBlockProcessor, timeout);
         await blockTimeoutDetector.start();

--- a/test/src/blockMonitor/confirmationObserver.test.ts
+++ b/test/src/blockMonitor/confirmationObserver.test.ts
@@ -1,10 +1,16 @@
 import "mocha";
 import * as chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import { ConfirmationObserver, BlockProcessor, BlockCache, IBlockStub } from "../../../src/blockMonitor";
+import { ConfirmationObserver, BlockProcessor, BlockCache } from "../../../src/blockMonitor";
 import { EventEmitter } from "events";
 import { ethers } from "ethers";
-import { ApplicationError, BlockThresholdReachedError, ReorgError } from "../../../src/dataEntities";
+import {
+    ApplicationError,
+    BlockThresholdReachedError,
+    ReorgError,
+    IBlockStub,
+    HasTxHashes
+} from "../../../src/dataEntities";
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
@@ -65,10 +71,10 @@ class PromiseSpy<T> {
 }
 
 describe("ConfirmationObserver", () => {
-    let blockCache: BlockCache;
-    let mockBlockProcessor: BlockProcessor;
+    let blockCache: BlockCache<IBlockStub & HasTxHashes>;
+    let mockBlockProcessor: BlockProcessor<IBlockStub & HasTxHashes>;
 
-    let confirmationObserver: ConfirmationObserver;
+    let confirmationObserver: ConfirmationObserver<IBlockStub & HasTxHashes>;
 
     async function emitNewHead(hash: string): Promise<void> {
         if (!(hash in blocksByHash)) {
@@ -91,7 +97,7 @@ describe("ConfirmationObserver", () => {
         }
 
         const eventEmitter = new EventEmitter();
-        mockBlockProcessor = eventEmitter as BlockProcessor; // we just need the mock to emit events
+        mockBlockProcessor = eventEmitter as BlockProcessor<IBlockStub & HasTxHashes>; // we just need the mock to emit events
 
         Object.defineProperty(mockBlockProcessor, "head", {
             value: null,

--- a/test/src/blockMonitor/confirmationObserver.test.ts
+++ b/test/src/blockMonitor/confirmationObserver.test.ts
@@ -9,7 +9,7 @@ import {
     BlockThresholdReachedError,
     ReorgError,
     IBlockStub,
-    HasTxHashes
+    Transactions
 } from "../../../src/dataEntities";
 
 chai.use(chaiAsPromised);
@@ -71,10 +71,10 @@ class PromiseSpy<T> {
 }
 
 describe("ConfirmationObserver", () => {
-    let blockCache: BlockCache<IBlockStub & HasTxHashes>;
-    let mockBlockProcessor: BlockProcessor<IBlockStub & HasTxHashes>;
+    let blockCache: BlockCache<IBlockStub & Transactions>;
+    let mockBlockProcessor: BlockProcessor<IBlockStub & Transactions>;
 
-    let confirmationObserver: ConfirmationObserver<IBlockStub & HasTxHashes>;
+    let confirmationObserver: ConfirmationObserver;
 
     async function emitNewHead(hash: string): Promise<void> {
         if (!(hash in blocksByHash)) {
@@ -97,7 +97,7 @@ describe("ConfirmationObserver", () => {
         }
 
         const eventEmitter = new EventEmitter();
-        mockBlockProcessor = eventEmitter as BlockProcessor<IBlockStub & HasTxHashes>; // we just need the mock to emit events
+        mockBlockProcessor = eventEmitter as BlockProcessor<IBlockStub & Transactions>; // we just need the mock to emit events
 
         Object.defineProperty(mockBlockProcessor, "head", {
             value: null,

--- a/test/src/endToEnd.test.ts
+++ b/test/src/endToEnd.test.ts
@@ -3,7 +3,7 @@ import { Watcher } from "../../src/watcher/watcher";
 import { KitsuneInspector, KitsuneAppointment, KitsuneTools } from "../../src/integrations/kitsune";
 import { ethers } from "ethers";
 import Ganache from "ganache-core";
-import { ChannelType, IBlockStub, HasTxHashes } from "../../src/dataEntities";
+import { ChannelType, IBlockStub, Transactions } from "../../src/dataEntities";
 import { EthereumResponderManager } from "../../src/responder";
 import { AppointmentStore } from "../../src/watcher/store";
 import { AppointmentSubscriber } from "../../src/watcher/appointmentSubscriber";
@@ -17,8 +17,8 @@ import {
 } from "../../src/blockMonitor";
 import levelup from "levelup";
 import MemDown from "memdown";
-import { ReorgEmitter } from "../../src/blockMonitor/reorgEmitter";
-import { minimalBlockFactory } from "../../src/blockMonitor/blockProcessor";
+import { ReorgEmitter, blockStubAndTxFactory } from "../../src/blockMonitor";
+
 const ganache = Ganache.provider({
     mnemonic: "myth like bonus scare over problem client lizard pioneer submit female collect"
 });
@@ -75,8 +75,12 @@ describe("End to end", () => {
         });
         await inspector.inspectAndPass(appointment);
 
-        const blockCache = new BlockCache<IBlockStub & HasTxHashes>(200);
-        const blockProcessor = new BlockProcessor<IBlockStub & HasTxHashes>(provider, minimalBlockFactory, blockCache);
+        const blockCache = new BlockCache<IBlockStub & Transactions>(200);
+        const blockProcessor = new BlockProcessor<IBlockStub & Transactions>(
+            provider,
+            blockStubAndTxFactory,
+            blockCache
+        );
         const reorgEmitter = new ReorgEmitter(provider, blockProcessor, new ReorgHeightListenerStore());
         await blockProcessor.start();
         await reorgEmitter.start();

--- a/test/src/endToEnd.test.ts
+++ b/test/src/endToEnd.test.ts
@@ -3,7 +3,7 @@ import { Watcher } from "../../src/watcher/watcher";
 import { KitsuneInspector, KitsuneAppointment, KitsuneTools } from "../../src/integrations/kitsune";
 import { ethers } from "ethers";
 import Ganache from "ganache-core";
-import { ChannelType } from "../../src/dataEntities";
+import { ChannelType, IBlockStub, HasTxHashes } from "../../src/dataEntities";
 import { EthereumResponderManager } from "../../src/responder";
 import { AppointmentStore } from "../../src/watcher/store";
 import { AppointmentSubscriber } from "../../src/watcher/appointmentSubscriber";
@@ -18,6 +18,7 @@ import {
 import levelup from "levelup";
 import MemDown from "memdown";
 import { ReorgEmitter } from "../../src/blockMonitor/reorgEmitter";
+import { minimalBlockFactory } from "../../src/blockMonitor/blockProcessor";
 const ganache = Ganache.provider({
     mnemonic: "myth like bonus scare over problem client lizard pioneer submit female collect"
 });
@@ -74,8 +75,8 @@ describe("End to end", () => {
         });
         await inspector.inspectAndPass(appointment);
 
-        const blockCache = new BlockCache(200);
-        const blockProcessor = new BlockProcessor(provider, blockCache);
+        const blockCache = new BlockCache<IBlockStub & HasTxHashes>(200);
+        const blockProcessor = new BlockProcessor<IBlockStub & HasTxHashes>(provider, minimalBlockFactory, blockCache);
         const reorgEmitter = new ReorgEmitter(provider, blockProcessor, new ReorgHeightListenerStore());
         await blockProcessor.start();
         await reorgEmitter.start();

--- a/test/src/responder.test.ts
+++ b/test/src/responder.test.ts
@@ -14,9 +14,17 @@ import {
     EthereumTransactionMiner
 } from "../../src/responder";
 import { CancellablePromise } from "../../src/utils";
-import { ChannelType, BlockThresholdReachedError, ReorgError, BlockTimeoutError } from "../../src/dataEntities";
+import {
+    ChannelType,
+    BlockThresholdReachedError,
+    ReorgError,
+    BlockTimeoutError,
+    IBlockStub,
+    HasTxHashes
+} from "../../src/dataEntities";
 import { BlockCache, BlockProcessor, BlockTimeoutDetector } from "../../src/blockMonitor";
 import { ConfirmationObserver } from "../../src/blockMonitor/confirmationObserver";
+import { minimalBlockFactory } from "../../src/blockMonitor/blockProcessor";
 
 chai.use(chaiAsPromised);
 chai.use(require("sinon-chai"));
@@ -151,10 +159,10 @@ function waitForSpy(spy: any, interval = 20) {
 describe("EthereumDedicatedResponder", () => {
     let ganache: any;
     let provider: ethers.providers.Web3Provider;
-    let blockCache: BlockCache;
-    let blockProcessor: BlockProcessor;
+    let blockCache: BlockCache<IBlockStub & HasTxHashes>;
+    let blockProcessor: BlockProcessor<IBlockStub & HasTxHashes>;
     let blockTimeoutDetector: BlockTimeoutDetector;
-    let confirmationObserver: ConfirmationObserver;
+    let confirmationObserver: ConfirmationObserver<IBlockStub & HasTxHashes>;
     let transactionMiner: EthereumTransactionMiner;
 
     let account0: string, account1: string, responderAccount: string;
@@ -167,8 +175,8 @@ describe("EthereumDedicatedResponder", () => {
         provider = new ethers.providers.Web3Provider(ganache);
         provider.pollingInterval = 100;
 
-        blockCache = new BlockCache(100);
-        blockProcessor = new BlockProcessor(provider, blockCache);
+        blockCache = new BlockCache<IBlockStub & HasTxHashes>(100);
+        blockProcessor = new BlockProcessor<IBlockStub & HasTxHashes>(provider, minimalBlockFactory, blockCache);
         await blockProcessor.start();
 
         blockTimeoutDetector = new BlockTimeoutDetector(blockProcessor, 120 * 1000);
@@ -469,10 +477,10 @@ describe("EthereumDedicatedResponder", () => {
 describe("EthereumTransactionMiner", async () => {
     let ganache: any;
     let provider: ethers.providers.Web3Provider;
-    let blockCache: BlockCache;
-    let blockProcessor: BlockProcessor;
+    let blockCache: BlockCache<IBlockStub & HasTxHashes>;
+    let blockProcessor: BlockProcessor<IBlockStub & HasTxHashes>;
     let blockTimeoutDetector: BlockTimeoutDetector;
-    let confirmationObserver: ConfirmationObserver;
+    let confirmationObserver: ConfirmationObserver<IBlockStub & HasTxHashes>;
     let accounts: string[];
     let account0Signer: ethers.Signer;
     let transactionRequest: ethers.providers.TransactionRequest;
@@ -483,8 +491,8 @@ describe("EthereumTransactionMiner", async () => {
         } as any); // TODO: remove generic types when @types/ganache-core is updated
         provider = new ethers.providers.Web3Provider(ganache);
         provider.pollingInterval = 20;
-        blockCache = new BlockCache(200);
-        blockProcessor = new BlockProcessor(provider, blockCache);
+        blockCache = new BlockCache<IBlockStub & HasTxHashes>(200);
+        blockProcessor = new BlockProcessor<IBlockStub & HasTxHashes>(provider, minimalBlockFactory, blockCache);
         await blockProcessor.start();
         blockTimeoutDetector = new BlockTimeoutDetector(blockProcessor, 120 * 1000);
         await blockTimeoutDetector.start();
@@ -545,6 +553,31 @@ describe("EthereumTransactionMiner", async () => {
 
     it("waitForFirstConfirmation throws BlockThresholdReachedError if the transaction is stuck", async () => {
         const blockThresholdForStuckTransaction = 10;
+        const spiedSigner = mockito.spy(account0Signer);
+
+        // Fake date for responses
+        const fakeTxReceipt: ethers.providers.TransactionReceipt = {
+            confirmations: 0,
+            from: "",
+            to: "",
+            byzantium: true
+        };
+        const fakeTxResponse: ethers.providers.TransactionResponse = {
+            hash: "0x1234", // only relevant value
+            confirmations: 0,
+            from: "",
+            to: "",
+            wait: (confirmations: number | undefined) => Promise.resolve(fakeTxReceipt),
+            nonce: 0,
+            gasLimit: new ethers.utils.BigNumber(21000),
+            gasPrice: new ethers.utils.BigNumber(20000000000),
+            data: "",
+            value: new ethers.utils.BigNumber(0),
+            chainId: 0
+        };
+
+        // Fake a response, but does not actually send the transaction
+        when(spiedSigner.sendTransaction(transactionRequest)).thenResolve(fakeTxResponse);
 
         const miner = new EthereumTransactionMiner(
             account0Signer,
@@ -558,9 +591,8 @@ describe("EthereumTransactionMiner", async () => {
         const res = miner.waitForFirstConfirmation(txHash);
 
         // Simulate blockThresholdForStuckTransaction new blocks without mining the transaction
-        const blockNumber = await provider.getBlockNumber();
         for (let i = 1; i <= blockThresholdForStuckTransaction + 1; i++) {
-            blockProcessor.emit(BlockProcessor.NEW_HEAD_EVENT, blockNumber + 1 + i, `hash${blockNumber + 1 + i}`);
+            await mineBlock(ganache, provider);
         }
 
         return expect(res).to.be.rejectedWith(BlockThresholdReachedError);

--- a/test/src/responder.test.ts
+++ b/test/src/responder.test.ts
@@ -548,6 +548,7 @@ describe("EthereumTransactionMiner", async () => {
         const txHash = await miner.sendTransaction(transactionRequest);
 
         const res = miner.waitForFirstConfirmation(txHash);
+        res.catch(() => {}); // ignore if it throwa
 
         // Simulates BLOCK_TIMEOUT_EVENT
         blockTimeoutDetector.emit(BlockTimeoutDetector.BLOCK_TIMEOUT_EVENT);
@@ -593,6 +594,7 @@ describe("EthereumTransactionMiner", async () => {
         const txHash = await miner.sendTransaction(transactionRequest);
 
         const res = miner.waitForFirstConfirmation(txHash);
+        res.catch(() => {}); // ignore if it throws
 
         // Simulate blockThresholdForStuckTransaction new blocks without mining the transaction
         for (let i = 1; i <= blockThresholdForStuckTransaction + 1; i++) {
@@ -635,6 +637,7 @@ describe("EthereumTransactionMiner", async () => {
         await miner.waitForFirstConfirmation(txHash);
 
         const res = miner.waitForEnoughConfirmations(txHash);
+        res.catch(() => {}); // ignore if it throws
 
         // Simulates BLOCK_TIMEOUT_EVENT
         blockTimeoutDetector.emit(BlockTimeoutDetector.BLOCK_TIMEOUT_EVENT);

--- a/test/src/responder.test.ts
+++ b/test/src/responder.test.ts
@@ -20,11 +20,15 @@ import {
     ReorgError,
     BlockTimeoutError,
     IBlockStub,
-    HasTxHashes
+    Transactions
 } from "../../src/dataEntities";
-import { BlockCache, BlockProcessor, BlockTimeoutDetector } from "../../src/blockMonitor";
-import { ConfirmationObserver } from "../../src/blockMonitor/confirmationObserver";
-import { minimalBlockFactory } from "../../src/blockMonitor/blockProcessor";
+import {
+    BlockCache,
+    BlockProcessor,
+    BlockTimeoutDetector,
+    ConfirmationObserver,
+    blockStubAndTxFactory
+} from "../../src/blockMonitor";
 
 chai.use(chaiAsPromised);
 chai.use(require("sinon-chai"));
@@ -159,10 +163,10 @@ function waitForSpy(spy: any, interval = 20) {
 describe("EthereumDedicatedResponder", () => {
     let ganache: any;
     let provider: ethers.providers.Web3Provider;
-    let blockCache: BlockCache<IBlockStub & HasTxHashes>;
-    let blockProcessor: BlockProcessor<IBlockStub & HasTxHashes>;
+    let blockCache: BlockCache<IBlockStub & Transactions>;
+    let blockProcessor: BlockProcessor<IBlockStub & Transactions>;
     let blockTimeoutDetector: BlockTimeoutDetector;
-    let confirmationObserver: ConfirmationObserver<IBlockStub & HasTxHashes>;
+    let confirmationObserver: ConfirmationObserver;
     let transactionMiner: EthereumTransactionMiner;
 
     let account0: string, account1: string, responderAccount: string;
@@ -175,8 +179,8 @@ describe("EthereumDedicatedResponder", () => {
         provider = new ethers.providers.Web3Provider(ganache);
         provider.pollingInterval = 100;
 
-        blockCache = new BlockCache<IBlockStub & HasTxHashes>(100);
-        blockProcessor = new BlockProcessor<IBlockStub & HasTxHashes>(provider, minimalBlockFactory, blockCache);
+        blockCache = new BlockCache<IBlockStub & Transactions>(100);
+        blockProcessor = new BlockProcessor<IBlockStub & Transactions>(provider, blockStubAndTxFactory, blockCache);
         await blockProcessor.start();
 
         blockTimeoutDetector = new BlockTimeoutDetector(blockProcessor, 120 * 1000);
@@ -477,10 +481,10 @@ describe("EthereumDedicatedResponder", () => {
 describe("EthereumTransactionMiner", async () => {
     let ganache: any;
     let provider: ethers.providers.Web3Provider;
-    let blockCache: BlockCache<IBlockStub & HasTxHashes>;
-    let blockProcessor: BlockProcessor<IBlockStub & HasTxHashes>;
+    let blockCache: BlockCache<IBlockStub & Transactions>;
+    let blockProcessor: BlockProcessor<IBlockStub & Transactions>;
     let blockTimeoutDetector: BlockTimeoutDetector;
-    let confirmationObserver: ConfirmationObserver<IBlockStub & HasTxHashes>;
+    let confirmationObserver: ConfirmationObserver;
     let accounts: string[];
     let account0Signer: ethers.Signer;
     let transactionRequest: ethers.providers.TransactionRequest;
@@ -491,8 +495,8 @@ describe("EthereumTransactionMiner", async () => {
         } as any); // TODO: remove generic types when @types/ganache-core is updated
         provider = new ethers.providers.Web3Provider(ganache);
         provider.pollingInterval = 20;
-        blockCache = new BlockCache<IBlockStub & HasTxHashes>(200);
-        blockProcessor = new BlockProcessor<IBlockStub & HasTxHashes>(provider, minimalBlockFactory, blockCache);
+        blockCache = new BlockCache<IBlockStub & Transactions>(200);
+        blockProcessor = new BlockProcessor<IBlockStub & Transactions>(provider, blockStubAndTxFactory, blockCache);
         await blockProcessor.start();
         blockTimeoutDetector = new BlockTimeoutDetector(blockProcessor, 120 * 1000);
         await blockTimeoutDetector.start();

--- a/test/src/watcher/watcher.test.ts
+++ b/test/src/watcher/watcher.test.ts
@@ -8,10 +8,14 @@ import { ethers } from "ethers";
 import { AppointmentSubscriber } from "../../../src/watcher/appointmentSubscriber";
 import * as Ganache from "ganache-core";
 import { EthereumResponderManager } from "../../../src/responder";
-import { BlockProcessor, ReorgHeightListenerStore, BlockCache } from "../../../src/blockMonitor";
-import { ReorgEmitter } from "../../../src/blockMonitor/reorgEmitter";
-import { IBlockStub, HasTxHashes } from "../../../src/dataEntities";
-import { minimalBlockFactory } from "../../../src/blockMonitor/blockProcessor";
+import {
+    BlockProcessor,
+    ReorgHeightListenerStore,
+    BlockCache,
+    ReorgEmitter,
+    blockStubAndTxFactory
+} from "../../../src/blockMonitor";
+import { IBlockStub, Transactions } from "../../../src/dataEntities";
 
 describe("Watcher", () => {
     const ganache = Ganache.provider({});
@@ -249,8 +253,12 @@ describe("Watcher", () => {
     });
 
     it("observe does nothing during a reorg", async () => {
-        const blockCache = new BlockCache<IBlockStub & HasTxHashes>(200);
-        const blockProcessor = new BlockProcessor<IBlockStub & HasTxHashes>(provider, minimalBlockFactory, blockCache);
+        const blockCache = new BlockCache<IBlockStub & Transactions>(200);
+        const blockProcessor = new BlockProcessor<IBlockStub & Transactions>(
+            provider,
+            blockStubAndTxFactory,
+            blockCache
+        );
         const reorgDetect = new ReorgEmitter(provider, blockProcessor, new ReorgHeightListenerStore());
         const spiedReorgDetect = spy(reorgDetect);
         const watcher = new Watcher(responderInstance, reorgDetect, appointmentSubscriber, storeInstanceThrow);

--- a/test/src/watcher/watcher.test.ts
+++ b/test/src/watcher/watcher.test.ts
@@ -10,6 +10,8 @@ import * as Ganache from "ganache-core";
 import { EthereumResponderManager } from "../../../src/responder";
 import { BlockProcessor, ReorgHeightListenerStore, BlockCache } from "../../../src/blockMonitor";
 import { ReorgEmitter } from "../../../src/blockMonitor/reorgEmitter";
+import { IBlockStub, HasTxHashes } from "../../../src/dataEntities";
+import { minimalBlockFactory } from "../../../src/blockMonitor/blockProcessor";
 
 describe("Watcher", () => {
     const ganache = Ganache.provider({});
@@ -247,8 +249,8 @@ describe("Watcher", () => {
     });
 
     it("observe does nothing during a reorg", async () => {
-        const blockCache = new BlockCache(200);
-        const blockProcessor = new BlockProcessor(provider, blockCache);
+        const blockCache = new BlockCache<IBlockStub & HasTxHashes>(200);
+        const blockProcessor = new BlockProcessor<IBlockStub & HasTxHashes>(provider, minimalBlockFactory, blockCache);
         const reorgDetect = new ReorgEmitter(provider, blockProcessor, new ReorgHeightListenerStore());
         const spiedReorgDetect = spy(reorgDetect);
         const watcher = new Watcher(responderInstance, reorgDetect, appointmentSubscriber, storeInstanceThrow);


### PR DESCRIPTION
Refactored BlockProcessor and BlockCache in order to:
- allow type-safe extensibility of the base IBlockStub type
- further separate the ethers.js types from the block cache (now only the block processor is aware of ethers.js)

Also removed the getConfirmations functionality from the BlockCache (and the related internal dictionary) and re-implemented it as an external functionality.

Fixed a test in EthereumTransactionMiner that was broken due to imperfect mocking.