### PR TITLE
BlockProcessor and BlockCache robustness and refactoring (WIP)

### DIFF
--- a/src/blockMonitor/blockCache.ts
+++ b/src/blockMonitor/blockCache.ts
@@ -274,7 +274,7 @@ export class BlockCache<TBlock extends IBlockStub> implements ReadOnlyBlockCache
      */
     public setHead(blockHash: string) {
         if (!this.hasBlock(blockHash)) {
-            throw new ArgumentError("Cannot set the head for a block that isn't in the cash.", blockHash);
+            throw new ArgumentError("Cannot set the head to be a block that isn't in the cache.", blockHash);
         }
         this.headHash = blockHash;
     }

--- a/src/blockMonitor/blockCache.ts
+++ b/src/blockMonitor/blockCache.ts
@@ -9,7 +9,7 @@ export interface ReadOnlyBlockCache<TBlock extends IBlockStub> {
     readonly maxHeight: number;
     readonly minHeight: number;
     canAddBlock(block: Readonly<TBlock>): boolean;
-    getBlockStub(blockHash: string): Readonly<TBlock>;
+    getBlock(blockHash: string): Readonly<TBlock>;
     hasBlock(blockHash: string): boolean;
     ancestry(initialBlockHash: string): IterableIterator<Readonly<TBlock>>;
     findAncestor(initialBlockHash: string, predicate: (block: Readonly<TBlock>) => boolean): Readonly<TBlock> | null;
@@ -33,9 +33,15 @@ export interface ReadOnlyBlockCache<TBlock extends IBlockStub> {
  *
  * Note that in order to guarantee the invariant (1), `addBlock` can be safely called even for blocks that will not
  * actually be added (for example because they are already too deep); in that case, it will return `false`.
+ *
+ * TODO:227: update documentation
  **/
 export class BlockCache<TBlock extends IBlockStub> implements ReadOnlyBlockCache<TBlock> {
-    private blockStubsByHash: Map<string, TBlock> = new Map();
+    // Blocks that are already
+    private blocksByHash: Map<string, TBlock> = new Map();
+
+    //blocks that can only be added once their parent is added
+    private pendingBlocksByHash: Map<string, TBlock> = new Map();
 
     // store block hashes at a specific height (there could be more than one at some height because of forks)
     private blockHashesByHeight: Map<number, Set<string>> = new Map();
@@ -72,22 +78,16 @@ export class BlockCache<TBlock extends IBlockStub> implements ReadOnlyBlockCache
      */
     constructor(public readonly maxDepth: number) {}
 
-    // Removes all info related to a block in blockStubsByHash
-    private removeBlock(blockHash: string) {
-        const block = this.blockStubsByHash.get(blockHash);
-        if (!block) {
-            // This would signal a bug
-            throw new ApplicationError(`Block with hash ${blockHash} not found, but it was expected.`);
-        }
-
-        this.blockStubsByHash.delete(blockHash);
-    }
-
     // Remove all the blocks that are deeper than maxDepth, and all connected information.
     private prune() {
         while (this.pruneHeight < this.minHeight) {
             for (const hash of this.blockHashesByHeight.get(this.pruneHeight) || []) {
-                this.removeBlock(hash);
+                const deleted = this.blocksByHash.delete(hash) || this.pendingBlocksByHash.delete(hash);
+
+                if (!deleted) {
+                    // This would signal a bug
+                    throw new ApplicationError(`Tried to delete block with hash ${hash}, but it does not exist.`);
+                }
             }
             this.blockHashesByHeight.delete(this.pruneHeight);
 
@@ -99,101 +99,131 @@ export class BlockCache<TBlock extends IBlockStub> implements ReadOnlyBlockCache
      * Returns true it `block` can be added to the cache, that is if either:
      *   - it is the first block ever seen, or
      *   - its parent is already in the cache, or
-     *   - it is at depth least `this.maxDepth`.
+     *   - it is at exactly `this.maxDepth`.
+     * If not, it can only be added to the pending.
      * @param block
      */
     public canAddBlock(block: Readonly<TBlock>): boolean {
-        return this.isEmpty || this.hasBlock(block.parentHash) || block.number <= this.minHeight;
+        return this.isEmpty || this.hasBlock(block.parentHash) || block.number === this.minHeight;
     }
 
-    /**
-     * `canAddBlock` might return true for blocks that should actually not be added.
-     * Here we check that the block is not actually already added, and it is not below a height
-     * that would be pruned immediately.
-     */
-    private shouldAddBlock(block: Readonly<TBlock>) {
-        if (this.blockStubsByHash.has(block.hash)) {
-            // block already in memory
-            return false;
+    // Processes all pending blocks at the given height, moving them to blocksByHeight if they are now complete.
+    // If so, add them and repeat with the next height (as some blocks might now have become complete)
+    private processPending(height: number) {
+        const blockHashesAtHeight = this.blockHashesByHeight.get(height) || new Set();
+        const blockHashesToAdd = [...blockHashesAtHeight].filter(h => this.pendingBlocksByHash.has(h));
+
+        for (const blockHash of blockHashesToAdd) {
+            const block = this.pendingBlocksByHash.get(blockHash)!;
+
+            // Remove block from pendingBlocksByHash, add to blocksByHash
+            this.blocksByHash.set(blockHash, block);
+            this.pendingBlocksByHash.delete(blockHash);
+
+            // Might need to update the maximum height
+            this.updateMaxHeightAndPrune(block.number);
         }
 
-        if (block.number < this.minHeight) {
-            // block too deep
-            return false;
+        if (blockHashesToAdd.length > 0) {
+            this.processPending(height + 1);
         }
-        return true;
+    }
+
+    // If minHeight is increased after adding some blocks, some previously pending blocks should now be moved into blocksByHash.
+    // Since the process itself could (in rare circumstances) also increase minHeight, we check if this is the case and repeat the cycle.
+    private processPendingBlocksAtMinHeight() {
+        let prevMinHeight: number;
+        do {
+            prevMinHeight = this.minHeight;
+            this.processPending(this.minHeight);
+        } while (this.minHeight > prevMinHeight); // if the minHeight increased, run again
+    }
+
+    private updateMaxHeightAndPrune(newHeight: number) {
+        // If the maximum block height increased, we might have to prune some old info
+        if (this.mMaxHeight < newHeight) {
+            this.mMaxHeight = newHeight;
+            this.prune();
+        }
     }
 
     /**
      * Adds `block`to the cache.
      * @param block
-     * @returns `true` if the block was added, `false` if the block was not added (because too deep or already in cache).
-     * @throws `ApplicationError` if the block cannot be added because its parent is not in cache.
+     * @returns `false` if the block was added (or was already present) as pending, `true` otherwise.
+     *      Note: it will return `true` even if the block was not actually added because already present, or because deeper than `maxDepth`.
      */
     public addBlock(block: Readonly<TBlock>): boolean {
-        // If the block's parent is above the minimum visible height, it needs to be added first
-        if (!this.canAddBlock(block)) {
-            throw new ApplicationError("Tried to add a block before its parent block.");
-        }
+        if (this.blocksByHash.has(block.hash)) return true; // block already added
+        if (block.number < this.minHeight) return true; // block already too deep, nothing to do
+
+        if (this.pendingBlocksByHash.has(block.hash)) return false; // block already pending
+
+        // From now on, we can assume that the block can be added (pending or not)
 
         if (this.isEmpty) {
             // First block added, store its height, so blocks before this point will not be stored.
             this.pruneHeight = block.number;
             this.isEmpty = false;
-        } else if (!this.shouldAddBlock(block)) {
-            // We do not actually need to add the block
-            return false;
         }
-
-        // Update data structures
-
-        // Save block
-        this.blockStubsByHash.set(block.hash, block);
 
         // Index block by its height
         const hashesByHeight = this.blockHashesByHeight.get(block.number);
-        if (hashesByHeight === undefined) {
-            this.blockHashesByHeight.set(block.number, new Set([block.hash]));
+        if (hashesByHeight == undefined) {
+            this.blockHashesByHeight.set(block.number, new Set([block.hash])); // create new Set
         } else {
-            hashesByHeight.add(block.hash);
+            hashesByHeight.add(block.hash); // add to existing Set
         }
 
-        // If the maximum block height increased, we might have to prune some old info
-        if (this.mMaxHeight < block.number) {
-            this.mMaxHeight = block.number;
-            this.prune();
-        }
+        if (this.canAddBlock(block)) {
+            this.blocksByHash.set(block.hash, block);
 
-        return true;
+            // If the maximum block height increased, we might have to prune some old info
+            this.updateMaxHeightAndPrune(block.number);
+
+            // Since we added a new block, some pending blocks might become complete
+            this.processPending(block.number + 1);
+
+            // If the minHeight increased, this could also make some pending blocks complete
+            // This makes sure that they are added if necessary
+            this.processPendingBlocksAtMinHeight();
+            return true;
+        } else {
+            this.pendingBlocksByHash.set(block.hash, block);
+            return false;
+        }
     }
 
     /**
-     * Returns the `IBlockStub` for the block with hash `blockHash`, or throws exception if the block is not in cache.
+     * Returns the block with hash `blockHash`, or throws exception if the block is not in cache.
      * @param blockHash
+     * TODO:227: do we want to allow pending blocks?
      */
-    public getBlockStub(blockHash: string): Readonly<TBlock> {
-        const blockStub = this.blockStubsByHash.get(blockHash);
-        if (!blockStub) throw new ApplicationError(`Block not found for hash: ${blockHash}.`);
-        return blockStub;
+    public getBlock(blockHash: string): Readonly<TBlock> {
+        const block = this.blocksByHash.get(blockHash);
+        if (!block) throw new ApplicationError(`Block not found for hash: ${blockHash}.`);
+        return block;
     }
 
     /**
      * Returns true if the block with hash `blockHash` is currently in cache.
+     * TODO:227: do we want to allow pending blocks?
      **/
     public hasBlock(blockHash: string): boolean {
-        return this.blockStubsByHash.has(blockHash);
+        return this.blocksByHash.has(blockHash);
     }
 
     /**
      * Iterator over all the blocks in the ancestry of the block with hash `initialBlockHash` (inclusive).
+     * The block needs to be complete.
      * @param initialBlockHash
      */
     public *ancestry(initialBlockHash: string): IterableIterator<Readonly<TBlock>> {
-        let curBlock = this.getBlockStub(initialBlockHash);
+        let curBlock = this.getBlock(initialBlockHash);
         while (true) {
             yield curBlock;
             if (this.hasBlock(curBlock.parentHash)) {
-                curBlock = this.getBlockStub(curBlock.parentHash);
+                curBlock = this.getBlock(curBlock.parentHash);
             } else break;
         }
     }
@@ -201,8 +231,12 @@ export class BlockCache<TBlock extends IBlockStub> implements ReadOnlyBlockCache
     /**
      * Finds and returns the nearest ancestor that satisfies `predicate`.
      * Returns `null` if no such ancestor is found.
+     * The block needs to be complete.
      */
-    public findAncestor(initialBlockHash: string, predicate: (block: Readonly<TBlock>) => boolean): Readonly<TBlock> | null {
+    public findAncestor(
+        initialBlockHash: string,
+        predicate: (block: Readonly<TBlock>) => boolean
+    ): Readonly<TBlock> | null {
         for (const block of this.ancestry(initialBlockHash)) {
             if (predicate(block)) {
                 return block;
@@ -212,9 +246,10 @@ export class BlockCache<TBlock extends IBlockStub> implements ReadOnlyBlockCache
     }
 
     /**
-     * Returns the oldest ancestor of `blockStub` that is stored in the blockCache.
-     * @throws ArgumentError if `blockHash` is not in the blockCache.
+     * Returns the oldest ancestor of `blockHash` that is stored in the blockCache.
+     * @throws `ArgumentError` if `blockHash` is not in the blockCache.
      * @param blockHash
+     * The block needs to be complete.
      */
     public getOldestAncestorInCache(blockHash: string): Readonly<TBlock> {
         if (!this.hasBlock(blockHash)) {
@@ -254,7 +289,7 @@ export class BlockCache<TBlock extends IBlockStub> implements ReadOnlyBlockCache
         if (this.headHash == null) {
             throw new ApplicationError("Head used before the BlockCache is initialized.");
         }
-        return this.getBlockStub(this.headHash);
+        return this.getBlock(this.headHash);
     }
 }
 
@@ -265,14 +300,14 @@ export class BlockCache<TBlock extends IBlockStub> implements ReadOnlyBlockCache
  * @param cache
  * @param headHash
  * @param txHash
- * @throws `ArgumentError` if the block with hash `headHash` is not in the cache.
+ * @throws `ArgumentError` if the block with hash `headHash` is not in the cache (or is pending).
  */
 export function getConfirmations<T extends IBlockStub & TransactionHashes>(
     cache: ReadOnlyBlockCache<T>,
     headHash: string,
     txHash: string
 ): number {
-    const headBlock = cache.getBlockStub(headHash);
+    const headBlock = cache.getBlock(headHash);
     const blockTxIsMinedIn = cache.findAncestor(headHash, block => block.transactionHashes.includes(txHash));
     if (!blockTxIsMinedIn) return 0;
     else return headBlock.number - blockTxIsMinedIn.number + 1;

--- a/src/blockMonitor/blockCache.ts
+++ b/src/blockMonitor/blockCache.ts
@@ -10,7 +10,7 @@ export interface ReadOnlyBlockCache<TBlock extends IBlockStub> {
     readonly minHeight: number;
     canAddBlock(block: Readonly<TBlock>): boolean;
     getBlock(blockHash: string): Readonly<TBlock>;
-    hasBlock(blockHash: string): boolean;
+    hasBlock(blockHash: string, includePending?: boolean): boolean;
     ancestry(initialBlockHash: string): IterableIterator<Readonly<TBlock>>;
     findAncestor(initialBlockHash: string, predicate: (block: Readonly<TBlock>) => boolean): Readonly<TBlock> | null;
     getOldestAncestorInCache(blockHash: string): TBlock;

--- a/src/blockMonitor/blockchainMachine.ts
+++ b/src/blockMonitor/blockchainMachine.ts
@@ -51,7 +51,7 @@ export class BlockchainMachine<TBlock extends IBlockStub> extends StartStopServi
             // Finally, if the parent is not available at all in the block cache, compute the initial state based on the current block.
 
             if (this.blockProcessor.blockCache.hasBlock(block.parentHash)) {
-                const parentBlock = this.blockProcessor.blockCache.getBlockStub(block.parentHash);
+                const parentBlock = this.blockProcessor.blockCache.getBlock(block.parentHash);
                 const prevAnchorState = states.get(parentBlock) || component.reducer.getInitialState(parentBlock);
 
                 states.set(block, component.reducer.reduce(prevAnchorState, block));

--- a/test/src/blockMonitor/blockCache.test.ts
+++ b/test/src/blockMonitor/blockCache.test.ts
@@ -37,7 +37,7 @@ describe("BlockCache", () => {
         const blocks = generateBlocks(1, 0, "main");
 
         bc.addBlock(blocks[0]);
-        expect(blocks[0]).to.deep.include(bc.getBlockStub(blocks[0].hash));
+        expect(blocks[0]).to.deep.include(bc.getBlock(blocks[0].hash));
     });
 
     it("minHeight is equal to the initial block height if less then maxDepth blocks are added", () => {
@@ -129,7 +129,7 @@ describe("BlockCache", () => {
         const blocks = generateBlocks(maxDepth, 0, "main");
         blocks.forEach(block => bc.addBlock(block));
 
-        expect(blocks[0]).to.deep.include(bc.getBlockStub(blocks[0].hash));
+        expect(blocks[0]).to.deep.include(bc.getBlock(blocks[0].hash));
     });
 
     it("forgets blocks past the maximum depth", () => {
@@ -137,7 +137,7 @@ describe("BlockCache", () => {
         const blocks = generateBlocks(maxDepth + 2, 0, "main"); // head is depth 0, so first pruned is maxDepth + 2
         blocks.forEach(block => bc.addBlock(block));
 
-        expect(() => bc.getBlockStub(blocks[0].hash)).to.throw(ApplicationError);
+        expect(() => bc.getBlock(blocks[0].hash)).to.throw(ApplicationError);
     });
 
     it("ancestry iterates over all the ancestors", () => {

--- a/test/src/blockMonitor/blockCache.test.ts
+++ b/test/src/blockMonitor/blockCache.test.ts
@@ -90,6 +90,7 @@ describe("BlockCache", () => {
         expect(bc.canAddBlock(otherBlocks[3])).to.be.true;
     });
 
+    //TODO:227: check this test
     it("canAddBlock returns false for blocks whose height is lower than the initial height", () => {
         const bc = new BlockCache(maxDepth);
 

--- a/test/src/blockMonitor/blockCache.test.ts
+++ b/test/src/blockMonitor/blockCache.test.ts
@@ -78,7 +78,7 @@ describe("BlockCache", () => {
         expect(bc.maxHeight).to.equal(lastBlockAdded);
     });
 
-    it("canAddBlock returns true for blocks whose height is lower or equal than the initial height", () => {
+    it("canAddBlock returns true for blocks whose height is equal than the initial height", () => {
         const bc = new BlockCache(maxDepth);
 
         const blocks = generateBlocks(10, 5, "main");
@@ -86,12 +86,22 @@ describe("BlockCache", () => {
 
         bc.addBlock(blocks[3]);
 
-        expect(bc.canAddBlock(blocks[2])).to.be.true;
         expect(bc.canAddBlock(blocks[3])).to.be.true;
         expect(bc.canAddBlock(otherBlocks[3])).to.be.true;
     });
 
-    it("canAddBlock returns true for blocks whose height is lower or equal than the maximum depth", () => {
+    it("canAddBlock returns false for blocks whose height is lower than the initial height", () => {
+        const bc = new BlockCache(maxDepth);
+
+        const blocks = generateBlocks(10, 5, "main");
+        const otherBlocks = generateBlocks(10, 5, "other");
+
+        bc.addBlock(blocks[3]);
+
+        expect(bc.canAddBlock(blocks[2])).to.be.false;
+    });
+
+    it("canAddBlock returns true for blocks whose height is equal than the maximum depth", () => {
         const bc = new BlockCache(maxDepth);
         const initialHeight = 3;
         const blocksAdded = maxDepth + 1;
@@ -100,8 +110,19 @@ describe("BlockCache", () => {
 
         const otherBlocks = generateBlocks(2, initialHeight - 1, "main");
 
-        expect(bc.canAddBlock(otherBlocks[0])).to.be.true;
         expect(bc.canAddBlock(otherBlocks[1])).to.be.true;
+    });
+
+    it("canAddBlock returns false for blocks whose height is lower than the maximum depth", () => {
+        const bc = new BlockCache(maxDepth);
+        const initialHeight = 3;
+        const blocksAdded = maxDepth + 1;
+        const blocks = generateBlocks(blocksAdded, initialHeight, "main");
+        blocks.forEach(block => bc.addBlock(block));
+
+        const otherBlocks = generateBlocks(2, initialHeight - 1, "main");
+
+        expect(bc.canAddBlock(otherBlocks[0])).to.be.false;
     });
 
     it("canAddBlock returns true for a block whose parent is in the BlockCache", () => {

--- a/test/src/blockMonitor/blockProcessor.test.ts
+++ b/test/src/blockMonitor/blockProcessor.test.ts
@@ -56,11 +56,18 @@ describe("BlockProcessor", () => {
         blockHash: string
     ) => {
         return new Promise(resolve => {
-            bp.on(BlockProcessor.NEW_BLOCK_EVENT, (head: IBlockStub) => {
-                expect(bc.hasBlock(blockHash)).to.be.true;
+            const newBlockHandler = (head: IBlockStub) => {
+                if (head.hash === blockHash) {
+                    if (!bc.hasBlock(blockHash)) {
+                        resolve(new Error(`Expected block with hash ${blockHash} not found in the BlockCache.`));
+                    } else {
+                        resolve({ number: head.number, hash: head.hash });
+                    }
+                    bp.off(BlockProcessor.NEW_BLOCK_EVENT, newBlockHandler);
+                }
+            };
 
-                resolve({ number: head.number, hash: head.hash });
-            });
+            bp.on(BlockProcessor.NEW_BLOCK_EVENT, newBlockHandler);
         });
     };
 
@@ -90,15 +97,24 @@ describe("BlockProcessor", () => {
 
         // The mocked Provider should behave like an eventEmitter
         const eventEmitter = new EventEmitter();
-        when(mockProvider.on(anything(), anything())).thenCall((arg0: any, arg1: any) => eventEmitter.on(arg0, arg1));
-        when(mockProvider.once(anything(), anything())).thenCall((arg0: any, arg1: any) =>
-            eventEmitter.once(arg0, arg1)
-        );
-        when(mockProvider.removeListener(anything(), anything())).thenCall((arg0: any, arg1: any) =>
-            eventEmitter.removeListener(arg0, arg1)
-        );
-        when(mockProvider.removeAllListeners(anything())).thenCall((arg0: any) =>
-            eventEmitter.removeAllListeners(arg0)
+        when(mockProvider.on(anything(), anything())).thenCall((arg0: any, arg1: any) => {
+            eventEmitter.on(arg0, arg1);
+            return provider;
+        });
+        when(mockProvider.once(anything(), anything())).thenCall((arg0: any, arg1: any) => {
+            eventEmitter.once(arg0, arg1);
+            return provider;
+        });
+        when(mockProvider.removeListener(anything(), anything())).thenCall((arg0: any, arg1: any) => {
+            eventEmitter.removeListener(arg0, arg1);
+            return provider;
+        });
+        when(mockProvider.removeAllListeners(anything())).thenCall((arg0: any) => {
+            eventEmitter.removeAllListeners(arg0);
+            return provider;
+        });
+        when(mockProvider.emit(anything(), anything())).thenCall((arg0: any, arg1: any) =>
+            eventEmitter.emit(arg0, arg1)
         );
 
         // We initially return 0 as the current block number
@@ -120,30 +136,39 @@ describe("BlockProcessor", () => {
         expect(blockProcessor.blockCache.head.hash).to.equal("a1");
     });
 
-    it("adds the first block received to the cache and emits a new head event", async () => {
+    it("adds the first block received to the cache and emits a NEW_HEAD_EVENT after the NEW_BLOCK_EVENTs", async () => {
+        emitBlockHash("a4");
+
         blockProcessor = new BlockProcessor(provider, blockStubAndTxFactory, blockCache);
         await blockProcessor.start();
 
-        const res = new Promise(resolve => {
+        let newHeadCalled = false;
+
+        const newHeadPromise = new Promise(resolve => {
             blockProcessor.on(BlockProcessor.NEW_HEAD_EVENT, (head: IBlockStub) => {
-                expect(blockCache.hasBlock("a5")).to.be.true;
+                newHeadCalled = true;
+                if (!blockCache.hasBlock("a5"))
+                    resolve(new Error(`The BlockCache did not have block a5 when its NEW_HEAD_EVENT was emitted`));
 
                 resolve({ number: head.number, hash: head.hash });
             });
         });
 
-        const newBlock = new Promise(resolve => {
-            blockProcessor.on(BlockProcessor.NEW_BLOCK_EVENT, (head: IBlockStub) => {
-                expect(blockCache.hasBlock("a5")).to.be.true;
-
-                resolve({ number: head.number, hash: head.hash });
-            });
+        let newHeadCalledBeforeNewBlock = false;
+        blockProcessor.once(BlockProcessor.NEW_BLOCK_EVENT, (block: IBlockStub) => {
+            if (newHeadCalled) {
+                // New head should be the last emitted event
+                newHeadCalledBeforeNewBlock = true;
+            }
         });
 
         emitBlockHash("a5");
 
-        expect(res).to.eventually.equal({ number: 5, hash: "a5" });
-        expect(newBlock).to.eventually.equal({ number: 5, hash: "a5" });
+        const resNewHead = await newHeadPromise;
+
+        expect(newHeadCalledBeforeNewBlock, "did not call NEW_HEAD before NEW_BLOCK").to.be.false;
+
+        return expect(resNewHead).to.deep.equal({ number: 5, hash: "a5" });
     });
 
     it("adds to the blockCache all ancestors until a known block", async () => {
@@ -154,16 +179,19 @@ describe("BlockProcessor", () => {
             subscribers.push(createNewBlockSubscriber(blockProcessor, blockCache, `a${i}`));
         }
 
-        await blockProcessor.start();
-
         emitBlockHash("a1");
+
+        await blockProcessor.start();
 
         emitBlockHash("a5");
 
-        subscribers.forEach((s, index) => {
-            expect(blockCache.hasBlock(`a${index}`));
-            expect(s).to.eventually.equal({ number: 5, hash: `a${index}` });
-        });
+        const results = await Promise.all(subscribers);
+        for (let i = 1; i <= 5; i++) {
+            expect(results[i - 1]).to.deep.equal({
+                number: i,
+                hash: `a${i}`
+            });
+        }
     });
 
     it("adds both chain until the common ancestor if there is a fork", async () => {
@@ -178,56 +206,28 @@ describe("BlockProcessor", () => {
             subscribersB.push(createNewBlockSubscriber(blockProcessor, blockCache, `b${i}`));
         }
 
+        emitBlockHash("a1");
+
         await blockProcessor.start();
 
-        emitBlockHash("a1");
         emitBlockHash("a6");
+
+        const resultsA = await Promise.all(subscribersA);
+        for (let i = 1; i <= 6; i++) {
+            expect(resultsA[i - 1]).to.deep.equal({
+                number: i,
+                hash: `a${i}`
+            });
+        }
+
         emitBlockHash("b6");
 
-        subscribersA.forEach((s, index) => {
-            expect(blockCache.hasBlock(`a${index}`));
-            expect(s).to.eventually.equal({ number: 5, hash: `a${index}` });
-        });
-        subscribersB.forEach((s, index) => {
-            expect(blockCache.hasBlock(`b${index}`));
-            expect(s).to.eventually.equal({ number: 5, hash: `b${index}` });
-        });
-    });
-
-    it("adds both chain until the common ancestor if there is a fork", async () => {
-        blockProcessor = new BlockProcessor(provider, blockStubAndTxFactory, blockCache);
-
-        const subscribersA = [];
-        for (let i = 1; i <= 10; i++) {
-            subscribersA.push(createNewBlockSubscriber(blockProcessor, blockCache, `a${i}`));
+        const resultsB = await Promise.all(subscribersB);
+        for (let i = 3; i <= 6; i++) {
+            expect(resultsB[i - 3]).to.deep.equal({
+                number: i,
+                hash: `b${i}`
+            });
         }
-        const subscribersB = [];
-        for (let i = 1; i <= 6; i++) {
-            subscribersB.push(createNewBlockSubscriber(blockProcessor, blockCache, `b${i}`));
-        }
-        const subscribersC = [];
-        for (let i = 1; i <= 10; i++) {
-            subscribersC.push(createNewBlockSubscriber(blockProcessor, blockCache, `c${i}`));
-        }
-
-        await blockProcessor.start();
-
-        emitBlockHash("a1");
-        emitBlockHash("a10");
-        emitBlockHash("b10");
-        emitBlockHash("c10");
-
-        subscribersA.forEach((s, index) => {
-            expect(blockCache.hasBlock(`a${index}`));
-            expect(s).to.eventually.equal({ number: 5, hash: `a${index}` });
-        });
-        subscribersB.forEach((s, index) => {
-            expect(blockCache.hasBlock(`b${index}`));
-            expect(s).to.eventually.equal({ number: 5, hash: `b${index}` });
-        });
-        subscribersC.forEach((s, index) => {
-            expect(blockCache.hasBlock(`c${index}`));
-            expect(s).to.eventually.equal({ number: 5, hash: `c${index}` });
-        });
     });
 });

--- a/test/src/watcher/watcher.test.ts
+++ b/test/src/watcher/watcher.test.ts
@@ -418,7 +418,7 @@ describe("Watcher", () => {
                 items: makeMap(appointment.id, {
                     state: WatcherAppointmentState.WATCHING
                 }),
-                blockNumber: 101 + CONFIRMATIONS_BEFORE_REMOVAL 
+                blockNumber: 101 + CONFIRMATIONS_BEFORE_REMOVAL
             },
             {
                 items: makeMap(appointment.id, {


### PR DESCRIPTION
Not quite ready to merge, but creating a PR anyway to get feedback. Description of the changes:

1) Modified the BlockCache to also allow adding blocks before adding their parent. Those blocks are considered "pending" and kept in a separate structure. `getBlock` will return a known block regardless if it's pending, while `hasBlock` allow to specify if pending blocks should be included or not. The addition of pending blocks allows to simplify the BlockProcessor's logic, at the cost of some more complexity in the BlockCache, as I added some non-trivial logic to make "pending" block become "complete" as soon as possible, while staying close to computationally optimal.
2) The BlockProcessor's logic is a bit different than before, in order to tolerate failures (e.g. from getBlock unexpectedly returning null). Right now, the behavior I implemented is a silent failure (which means, it will try again at the next new_head event from the provider, but previously downloaded blocks are added to the cache (as pending), so they would't be downloaded again.
3) I also changed the behavior of the NEW_BLOCK event of the BlockProcessor, which is now re-emitting blocks that were already emitted in case of switching forks multiple times. It would be easy to change this back, and I did not yet wrap my head what's best.

All in all, I'm quite happy with the test coverage of the BlockCache, while I trust the BlockProcessor work a bit less; it's a bit harder to think of good tests here, though.