### PR TITLE
Improved robustness of BlockProcessor, added support for pending blocks in BlockCache

### DIFF
--- a/src/blockMonitor/blockCache.ts
+++ b/src/blockMonitor/blockCache.ts
@@ -100,11 +100,11 @@ export class BlockCache<TBlock extends IBlockStub> implements ReadOnlyBlockCache
     }
 
     /**
-     * Returns true it `block` can be added to the cache, that is if either:
-     *   - it is the first block ever seen, or
-     *   - its parent is already in the cache, or
-     *   - it is at exactly `this.maxDepth`.
-     * If not, it can only be added as detached.
+     * Returns true if `block` can be attached to the cache, that is any of the following conditions is true:
+     *   - the block cache is still empty, so we consider the first block attached by definition;
+     *   - its parent is already in the cache;
+     *   - it is at depth exactly `this.maxDepth`, as the cache does not record its parents anyway.
+     * If not, `block` can only be added as detached.
      * @param block
      */
     public canAttachBlock(block: Readonly<TBlock>): boolean {

--- a/src/blockMonitor/blockCache.ts
+++ b/src/blockMonitor/blockCache.ts
@@ -90,8 +90,7 @@ export class BlockCache<TBlock extends IBlockStub> implements ReadOnlyBlockCache
                 const deleted = this.blocksByHash.delete(hash) || this.detachedBlocksByHash.delete(hash);
 
                 // This would signal a bug
-                if (!deleted)
-                    throw new ApplicationError(`Tried to delete block with hash ${hash}, but it does not exist.`);
+                if (!deleted) throw new ApplicationError(`Tried to delete block with hash ${hash}, but it does not exist.`); // prettier-ignore
             }
             this.blockHashesByHeight.delete(this.pruneHeight);
 

--- a/src/blockMonitor/blockCache.ts
+++ b/src/blockMonitor/blockCache.ts
@@ -9,8 +9,8 @@ export interface ReadOnlyBlockCache<TBlock extends IBlockStub> {
     readonly maxHeight: number;
     readonly minHeight: number;
     canAddBlock(block: Readonly<TBlock>): boolean;
-    getBlockStub(blockHash: string): Readonly<TBlock>;
-    hasBlock(blockHash: string): boolean;
+    getBlock(blockHash: string): Readonly<TBlock>;
+    hasBlock(blockHash: string, includePending?: boolean): boolean;
     ancestry(initialBlockHash: string): IterableIterator<Readonly<TBlock>>;
     findAncestor(
         initialBlockHash: string,
@@ -25,21 +25,20 @@ export interface ReadOnlyBlockCache<TBlock extends IBlockStub> {
  * Utility class to store and query info on full blocks up to a given maximum depth `maxDepth`, compared to the current
  * maximum height ever seen.
  * It prunes all the blocks at depth bigger than `maxDepth`, or with height smaller than the first block that was added.
- * It does not allow to add blocks without adding their parent first, except if they are at depth `maxDepth`.
+ * Added blocks are considered `complete` if they are at depth `maxDepth`, or if their parent is `complete`.
  *
  * The following invariants are guaranteed:
- * 1) Adding a block after the parent was added will never throw an exception.
- * 2) No block at depth more than `maxDepth` is still found in the structure.
- * 3) No block is retained if its height is smaller than the first block ever added.
- * 4) All blocks added are never pruned if their depth is less then `maxDepth`.
- * 5) No block can be added before their parent, unless their height is equal to the height of the first added block, or
- *    their depth is `maxDepth`.
- *
- * Note that in order to guarantee the invariant (1), `addBlock` can be safely called even for blocks that will not
- * actually be added (for example because they are already too deep); in that case, it will return `false`.
+ * 1) No complete or pending block at depth more than `maxDepth` is still found in the structure, where the depth is computed
+ *    with respect to the highest block number of a complete block.
+ * 2) No block is retained if its height is smaller than the first block ever added.
+ * 3) All added blocks are never pruned if their depth is less then `maxDepth`.
  **/
 export class BlockCache<TBlock extends IBlockStub> implements ReadOnlyBlockCache<TBlock> {
-    private blockStubsByHash: Map<string, TBlock> = new Map();
+    // Blocks that are already
+    private blocksByHash: Map<string, TBlock> = new Map();
+
+    //blocks that can only be added once their parent is added
+    private pendingBlocksByHash: Map<string, TBlock> = new Map();
 
     // store block hashes at a specific height (there could be more than one at some height because of forks)
     private blockHashesByHeight: Map<number, Set<string>> = new Map();
@@ -76,22 +75,16 @@ export class BlockCache<TBlock extends IBlockStub> implements ReadOnlyBlockCache
      */
     constructor(public readonly maxDepth: number) {}
 
-    // Removes all info related to a block in blockStubsByHash
-    private removeBlock(blockHash: string) {
-        const block = this.blockStubsByHash.get(blockHash);
-        if (!block) {
-            // This would signal a bug
-            throw new ApplicationError(`Block with hash ${blockHash} not found, but it was expected.`);
-        }
-
-        this.blockStubsByHash.delete(blockHash);
-    }
-
     // Remove all the blocks that are deeper than maxDepth, and all connected information.
     private prune() {
         while (this.pruneHeight < this.minHeight) {
             for (const hash of this.blockHashesByHeight.get(this.pruneHeight) || []) {
-                this.removeBlock(hash);
+                const deleted = this.blocksByHash.delete(hash) || this.pendingBlocksByHash.delete(hash);
+
+                if (!deleted) {
+                    // This would signal a bug
+                    throw new ApplicationError(`Tried to delete block with hash ${hash}, but it does not exist.`);
+                }
             }
             this.blockHashesByHeight.delete(this.pruneHeight);
 
@@ -103,101 +96,129 @@ export class BlockCache<TBlock extends IBlockStub> implements ReadOnlyBlockCache
      * Returns true it `block` can be added to the cache, that is if either:
      *   - it is the first block ever seen, or
      *   - its parent is already in the cache, or
-     *   - it is at depth least `this.maxDepth`.
+     *   - it is at exactly `this.maxDepth`.
+     * If not, it can only be added to the pending.
      * @param block
      */
     public canAddBlock(block: Readonly<TBlock>): boolean {
-        return this.isEmpty || this.hasBlock(block.parentHash) || block.number <= this.minHeight;
+        return this.isEmpty || this.hasBlock(block.parentHash) || block.number === this.minHeight;
     }
 
-    /**
-     * `canAddBlock` might return true for blocks that should actually not be added.
-     * Here we check that the block is not actually already added, and it is not below a height
-     * that would be pruned immediately.
-     */
-    private shouldAddBlock(block: Readonly<TBlock>) {
-        if (this.blockStubsByHash.has(block.hash)) {
-            // block already in memory
-            return false;
+    // Processes all pending blocks at the given height, moving them to blocksByHeight if they are now complete.
+    // If so, add them and repeat with the next height (as some blocks might now have become complete)
+    private processPending(height: number) {
+        const blockHashesAtHeight = this.blockHashesByHeight.get(height) || new Set();
+        const blockHashesToAdd = [...blockHashesAtHeight].filter(h => this.pendingBlocksByHash.has(h));
+
+        for (const blockHash of blockHashesToAdd) {
+            const block = this.pendingBlocksByHash.get(blockHash)!;
+
+            // Remove block from pendingBlocksByHash, add to blocksByHash
+            this.blocksByHash.set(blockHash, block);
+            this.pendingBlocksByHash.delete(blockHash);
+
+            // Might need to update the maximum height
+            this.updateMaxHeightAndPrune(block.number);
         }
 
-        if (block.number < this.minHeight) {
-            // block too deep
-            return false;
+        if (blockHashesToAdd.length > 0) {
+            this.processPending(height + 1);
         }
-        return true;
+    }
+
+    // If minHeight is increased after adding some blocks, some previously pending blocks should now be moved into blocksByHash.
+    // Since the process itself could (in rare circumstances) also increase minHeight, we check if this is the case and repeat the cycle.
+    private processPendingBlocksAtMinHeight() {
+        let prevMinHeight: number;
+        do {
+            prevMinHeight = this.minHeight;
+            this.processPending(this.minHeight);
+        } while (this.minHeight > prevMinHeight); // if the minHeight increased, run again
+    }
+
+    private updateMaxHeightAndPrune(newHeight: number) {
+        // If the maximum block height increased, we might have to prune some old info
+        if (this.mMaxHeight < newHeight) {
+            this.mMaxHeight = newHeight;
+            this.prune();
+        }
     }
 
     /**
      * Adds `block`to the cache.
      * @param block
-     * @returns `true` if the block was added, `false` if the block was not added (because too deep or already in cache).
-     * @throws `ApplicationError` if the block cannot be added because its parent is not in cache.
+     * @returns `false` if the block was added (or was already present) as pending, `true` otherwise.
+     *      Note: it will return `true` even if the block was not actually added because already present, or because deeper than `maxDepth`.
      */
     public addBlock(block: Readonly<TBlock>): boolean {
-        // If the block's parent is above the minimum visible height, it needs to be added first
-        if (!this.canAddBlock(block)) {
-            throw new ApplicationError("Tried to add a block before its parent block.");
-        }
+        if (this.blocksByHash.has(block.hash)) return true; // block already added
+        if (block.number < this.minHeight) return true; // block already too deep, nothing to do
+
+        if (this.pendingBlocksByHash.has(block.hash)) return false; // block already pending
+
+        // From now on, we can assume that the block can be added (pending or not)
 
         if (this.isEmpty) {
             // First block added, store its height, so blocks before this point will not be stored.
             this.pruneHeight = block.number;
             this.isEmpty = false;
-        } else if (!this.shouldAddBlock(block)) {
-            // We do not actually need to add the block
-            return false;
         }
-
-        // Update data structures
-
-        // Save block
-        this.blockStubsByHash.set(block.hash, block);
 
         // Index block by its height
         const hashesByHeight = this.blockHashesByHeight.get(block.number);
-        if (hashesByHeight === undefined) {
-            this.blockHashesByHeight.set(block.number, new Set([block.hash]));
+        if (hashesByHeight == undefined) {
+            this.blockHashesByHeight.set(block.number, new Set([block.hash])); // create new Set
         } else {
-            hashesByHeight.add(block.hash);
+            hashesByHeight.add(block.hash); // add to existing Set
         }
 
-        // If the maximum block height increased, we might have to prune some old info
-        if (this.mMaxHeight < block.number) {
-            this.mMaxHeight = block.number;
-            this.prune();
-        }
+        if (this.canAddBlock(block)) {
+            this.blocksByHash.set(block.hash, block);
 
-        return true;
+            // If the maximum block height increased, we might have to prune some old info
+            this.updateMaxHeightAndPrune(block.number);
+
+            // Since we added a new block, some pending blocks might become complete
+            this.processPending(block.number + 1);
+
+            // If the minHeight increased, this could also make some pending blocks complete
+            // This makes sure that they are added if necessary
+            this.processPendingBlocksAtMinHeight();
+            return true;
+        } else {
+            this.pendingBlocksByHash.set(block.hash, block);
+            return false;
+        }
     }
 
     /**
-     * Returns the `IBlockStub` for the block with hash `blockHash`, or throws exception if the block is not in cache.
+     * Returns the block with hash `blockHash`, or throws exception if the block is not in cache (complete nor pending).
      * @param blockHash
      */
-    public getBlockStub(blockHash: string): Readonly<TBlock> {
-        const blockStub = this.blockStubsByHash.get(blockHash);
-        if (!blockStub) throw new ApplicationError(`Block not found for hash: ${blockHash}.`);
-        return blockStub;
+    public getBlock(blockHash: string): Readonly<TBlock> {
+        const block = this.blocksByHash.get(blockHash) || this.pendingBlocksByHash.get(blockHash);
+        if (!block) throw new ApplicationError(`Block not found for hash: ${blockHash}.`);
+        return block;
     }
 
     /**
-     * Returns true if the block with hash `blockHash` is currently in cache.
+     * Returns true if the block with hash `blockHash` is currently in cache; if `includePending` is `true`, pending blocks are also considered.
      **/
-    public hasBlock(blockHash: string): boolean {
-        return this.blockStubsByHash.has(blockHash);
+    public hasBlock(blockHash: string, includePending: boolean = false): boolean {
+        return this.blocksByHash.has(blockHash) || (includePending && this.pendingBlocksByHash.has(blockHash));
     }
 
     /**
      * Iterator over all the blocks in the ancestry of the block with hash `initialBlockHash` (inclusive).
+     * The block with hash `initialBlockHash` must be complete.
      * @param initialBlockHash
      */
     public *ancestry(initialBlockHash: string): IterableIterator<Readonly<TBlock>> {
-        let curBlock = this.getBlockStub(initialBlockHash);
+        let curBlock = this.getBlock(initialBlockHash);
         while (true) {
             yield curBlock;
             if (this.hasBlock(curBlock.parentHash)) {
-                curBlock = this.getBlockStub(curBlock.parentHash);
+                curBlock = this.getBlock(curBlock.parentHash);
             } else break;
         }
     }
@@ -223,9 +244,10 @@ export class BlockCache<TBlock extends IBlockStub> implements ReadOnlyBlockCache
     }
 
     /**
-     * Returns the oldest ancestor of `blockStub` that is stored in the blockCache.
-     * @throws ArgumentError if `blockHash` is not in the blockCache.
+     * Returns the oldest ancestor of `blockHash` that is stored in the blockCache.
+     * @throws `ArgumentError` if `blockHash` is not in the blockCache.
      * @param blockHash
+     * The block with hash `blockHash` must be complete.
      */
     public getOldestAncestorInCache(blockHash: string): Readonly<TBlock> {
         if (!this.hasBlock(blockHash)) {
@@ -245,12 +267,12 @@ export class BlockCache<TBlock extends IBlockStub> implements ReadOnlyBlockCache
 
     /**
      * Sets the head block in the cache. AddBlock must be called before setHead can be
-     * called for that hash.
+     * called for that hash, and the block must be complete.
      * @param blockHash
      */
     public setHead(blockHash: string) {
         if (!this.hasBlock(blockHash)) {
-            throw new ArgumentError("Cannot set the head for a block that isn't in the cash.", blockHash);
+            throw new ArgumentError("Cannot set the head to be a block that isn't in the cache.", blockHash);
         }
         this.headHash = blockHash;
     }
@@ -265,7 +287,7 @@ export class BlockCache<TBlock extends IBlockStub> implements ReadOnlyBlockCache
         if (this.headHash == null) {
             throw new ApplicationError("Head used before the BlockCache is initialized.");
         }
-        return this.getBlockStub(this.headHash);
+        return this.getBlock(this.headHash);
     }
 }
 
@@ -276,14 +298,14 @@ export class BlockCache<TBlock extends IBlockStub> implements ReadOnlyBlockCache
  * @param cache
  * @param headHash
  * @param txHash
- * @throws `ArgumentError` if the block with hash `headHash` is not in the cache.
+ * @throws `ArgumentError` if the block with hash `headHash` is not in the cache or is not complete.
  */
 export function getConfirmations<T extends IBlockStub & TransactionHashes>(
     cache: ReadOnlyBlockCache<T>,
     headHash: string,
     txHash: string
 ): number {
-    const headBlock = cache.getBlockStub(headHash);
+    const headBlock = cache.getBlock(headHash);
     const blockTxIsMinedIn = cache.findAncestor(headHash, block => block.transactionHashes.includes(txHash));
     if (!blockTxIsMinedIn) return 0;
     else return headBlock.number - blockTxIsMinedIn.number + 1;

--- a/src/blockMonitor/blockCache.ts
+++ b/src/blockMonitor/blockCache.ts
@@ -17,7 +17,6 @@ export interface ReadOnlyBlockCache<TBlock extends IBlockStub> {
     readonly maxDepth: number;
     readonly maxHeight: number;
     readonly minHeight: number;
-    canAddBlock(block: Readonly<TBlock>): boolean;
     getBlock(blockHash: string): Readonly<TBlock>;
     hasBlock(blockHash: string, includeDetached?: boolean): boolean;
     ancestry(initialBlockHash: string): IterableIterator<Readonly<TBlock>>;
@@ -108,7 +107,7 @@ export class BlockCache<TBlock extends IBlockStub> implements ReadOnlyBlockCache
      * If not, it can only be added as detached.
      * @param block
      */
-    public canAddBlock(block: Readonly<TBlock>): boolean {
+    public canAttachBlock(block: Readonly<TBlock>): boolean {
         return this.isEmpty || this.hasBlock(block.parentHash) || block.number === this.minHeight;
     }
 
@@ -180,7 +179,7 @@ export class BlockCache<TBlock extends IBlockStub> implements ReadOnlyBlockCache
             hashesByHeight.add(block.hash); // add to existing Set
         }
 
-        if (this.canAddBlock(block)) {
+        if (this.canAttachBlock(block)) {
             this.blocksByHash.set(block.hash, block);
 
             // If the maximum block height increased, we might have to prune some old info

--- a/src/blockMonitor/blockProcessor.ts
+++ b/src/blockMonitor/blockProcessor.ts
@@ -162,7 +162,15 @@ export class BlockProcessor<TBlock extends IBlockStub> extends StartStopService 
             const observedBlock = await this.getBlockRemote(blockNumber);
             if (observedBlock == null) {
                 // No recovery needed, will pick this block up a next new_head event
-                this.logger.info(`Failed to retreive block with number ${blockNumber}.`);
+                this.logger.info(`Failed to retrieve block with number ${blockNumber}.`);
+                return;
+            }
+
+            if (this.blockCache.hasBlock(observedBlock.hash, true)) {
+                // We received a block that we already processed before. Ignore, but log that it happened
+                this.logger.info(
+                    `Received block #${blockNumber} with hash ${observedBlock.hash}, that was already known. Skipping.`
+                );
                 return;
             }
 

--- a/src/blockMonitor/blockProcessor.ts
+++ b/src/blockMonitor/blockProcessor.ts
@@ -80,11 +80,11 @@ export class BlockProcessor<TBlock extends IBlockStub> extends StartStopService 
     public static readonly NEW_HEAD_EVENT = "new_head";
 
     /**
-     * Event that is emitted for all blocks that have not previously been observed. If
-     * a block is the new head it will also be emitted via the NEW_HEAD_EVENT, however
-     * NEW_BLOCK_EVENT is guaranteed to emit first. Since this event emits for all new
-     * blocks it does not guarantee that an emitted block will be in the ancestry of the next
-     * emitted NEW_HEAD_EVENT.
+     * Event that is emitted for each new blocks. It is emitted (in order from the lowest-height block) for each block
+     * in the ancestry of the current blockchain head that is deeper than the last block in the ancestry that was emitted
+     * in a previous NEW_HEAD_EVENT. The NEW_HEAD_EVENT for the latest head block is guaranteed to be emitted after all the
+     * NEW_BLOCK_EVENTs in the ancestry have been emitted.
+     * A NEW_BLOCK_EVENT might happen to be emitted multiple times for the same block in case of blokchain re-orgs.
      */
     public static readonly NEW_BLOCK_EVENT = "new_block";
 

--- a/src/blockMonitor/blockProcessor.ts
+++ b/src/blockMonitor/blockProcessor.ts
@@ -1,15 +1,20 @@
 import { ethers } from "ethers";
-import { StartStopService, ApplicationError } from "../dataEntities";
+import { StartStopService } from "../dataEntities";
 import { ReadOnlyBlockCache, BlockCache } from "./blockCache";
 import { IBlockStub } from "../dataEntities";
 import { Block, TransactionHashes } from "../dataEntities/block";
 
-type BlockFactory<T> = (provider: ethers.providers.Provider) => (blockNumberOrHash: number | string) => Promise<T>;
+type BlockFactory<TBlock> = (
+    provider: ethers.providers.Provider
+) => (blockNumberOrHash: number | string) => Promise<TBlock | null>;
 
 export const blockStubAndTxHashFactory = (provider: ethers.providers.Provider) => async (
     blockNumberOrHash: string | number
-): Promise<IBlockStub & TransactionHashes> => {
+): Promise<IBlockStub & TransactionHashes | null> => {
     const block = await provider.getBlock(blockNumberOrHash);
+    if (!block) {
+        return null;
+    }
     return {
         hash: block.hash,
         number: block.number,
@@ -20,9 +25,12 @@ export const blockStubAndTxHashFactory = (provider: ethers.providers.Provider) =
 
 export const blockFactory = (provider: ethers.providers.Provider) => async (
     blockNumberOrHash: string | number
-): Promise<Block> => {
+): Promise<Block | null> => {
     const block = await provider.getBlock(blockNumberOrHash, true);
 
+    if (!block) {
+        return null;
+    }
     // We could filter out the logs that we are not interesting in order to save space
     // (e.g.: only keep the logs from the DataRegistry).
     const logs = await provider.getLogs({
@@ -45,21 +53,22 @@ export const blockFactory = (provider: ethers.providers.Provider) => async (
  * It generates a `NEW_HEAD_EVENT` every time a new block is received by the provider, but only after populating
  * the `blockCache` with the new block and its ancestors.
  */
-export class BlockProcessor<T extends IBlockStub> extends StartStopService {
+export class BlockProcessor<TBlock extends IBlockStub> extends StartStopService {
     // keeps track of the last block hash received, in order to correctly emit NEW_HEAD_EVENT; null on startup
     private lastBlockHashReceived: string | null;
 
-    // for set of blocks currently emitted as head block
-    private emittedBlocks: WeakSet<Readonly<T>> = new WeakSet();
+    // set of blocks currently emitted in a NEW_HEAD_EVENT
+    private emittedBlockHeads: WeakSet<Readonly<TBlock>> = new WeakSet();
 
-    private mBlockCache: BlockCache<T>;
+    private mBlockCache: BlockCache<TBlock>;
 
-    private getBlock: (blockNumberOrHash: string | number) => Promise<T>;
+    // Returned in the constructor by blockProvider: obtains the block remotely
+    private getBlockRemote: (blockNumberOrHash: string | number) => Promise<TBlock | null>;
 
     /**
      * Returns the ReadOnlyBlockCache associated to this BlockProcessor.
      */
-    public get blockCache(): ReadOnlyBlockCache<T> {
+    public get blockCache(): ReadOnlyBlockCache<TBlock> {
         return this.mBlockCache;
     }
 
@@ -81,12 +90,12 @@ export class BlockProcessor<T extends IBlockStub> extends StartStopService {
 
     constructor(
         private provider: ethers.providers.BaseProvider,
-        blockFactory: BlockFactory<T>,
-        blockCache: BlockCache<T>
+        blockFactory: BlockFactory<TBlock>,
+        blockCache: BlockCache<TBlock>
     ) {
         super("block-processor");
 
-        this.getBlock = blockFactory(provider);
+        this.getBlockRemote = blockFactory(provider);
         this.mBlockCache = blockCache;
 
         this.processBlockNumber = this.processBlockNumber.bind(this);
@@ -111,41 +120,61 @@ export class BlockProcessor<T extends IBlockStub> extends StartStopService {
     }
 
     // updates the new head block in the cache and emits the appropriate events
-    private processNewHead(headBlock: Readonly<T>) {
+    private processNewHead(headBlock: Readonly<TBlock>) {
         this.mBlockCache.setHead(headBlock.hash);
-        const nearestEmittedBlockInAncestry = this.blockCache.findAncestor(headBlock.hash, block =>
-            this.emittedBlocks.has(block)
-        );
 
-        this.emit(BlockProcessor.NEW_HEAD_EVENT, headBlock, nearestEmittedBlockInAncestry);
-        this.emittedBlocks.add(headBlock);
+        // only emit events after it's started
+        if (this.started) {
+            const nearestEmittedHeadInAncestry = this.blockCache.findAncestor(headBlock.hash, block =>
+                this.emittedBlockHeads.has(block)
+            );
+
+            const ancestry = [...this.blockCache.ancestry(headBlock.hash)].reverse();
+            const firstBlockIndex = nearestEmittedHeadInAncestry
+                ? ancestry.findIndex(block => block.parentHash === nearestEmittedHeadInAncestry.hash)
+                : 0;
+            const blocksToEmit = ancestry.slice(firstBlockIndex);
+
+            // TODO:227: this is different than before, as a NEW_BLOCK_EVENT will happen multiple times for the same block in case of multiple reorgs.
+            //           Could restore a behavior similar to the old one by keeping track of all the emitted blocks (rather than only the heads) in a WeakMap.
+            for (const block of blocksToEmit) {
+                this.emit(BlockProcessor.NEW_BLOCK_EVENT, block);
+            }
+
+            this.emit(BlockProcessor.NEW_HEAD_EVENT, headBlock, nearestEmittedHeadInAncestry);
+            this.emittedBlockHeads.add(headBlock);
+        }
     }
 
+    // Checks if a block is already in the block cache; if not, requests it remotely.
+    private async getBlock(blockHash: string) {
+        if (this.blockCache.hasBlock(blockHash, true)) {
+            return this.blockCache.getBlock(blockHash);
+        } else {
+            return this.getBlockRemote(blockHash);
+        }
+    }
     // Processes a new block, adding it to the cache and emitting the appropriate events
     // It is called for each new block received, but also at startup (during startInternal).
     private async processBlockNumber(blockNumber: number) {
         try {
-            const observedBlock = await this.getBlock(blockNumber);
+            const observedBlock = await this.getBlockRemote(blockNumber);
+            if (observedBlock == null) {
+                // TODO:227: what to do if block is null? Is failing silently ok?
+                return;
+            }
 
             this.lastBlockHashReceived = observedBlock.hash;
 
-            const blocksToAdd = [observedBlock]; // blocks to add, in reverse order
-
             // fetch ancestors until one is found that can be added
-            let curBlock = observedBlock;
-            while (!this.blockCache.canAddBlock(curBlock)) {
+            let curBlock: Readonly<TBlock> | null = observedBlock;
+            while (!this.mBlockCache.addBlock(curBlock!)) {
                 curBlock = await this.getBlock(curBlock.parentHash);
-                blocksToAdd.push(curBlock);
-            }
-            blocksToAdd.reverse(); // add blocks from the oldest
 
-            // populate fetched blocks into cache, starting from the deepest
-            for (const block of blocksToAdd) {
-                this.mBlockCache.addBlock(block);
-
-                // we've added this block and its ancestors
-                // to the cache, so we we're safe to inform subscribers
-                this.emit(BlockProcessor.NEW_BLOCK_EVENT, block);
+                if (!curBlock) {
+                    // TODO:227: how to recover if block returns null here? Fail silently?
+                    break;
+                }
             }
 
             // is the observed block still the last block received (or the first block during startup)?
@@ -153,7 +182,9 @@ export class BlockProcessor<T extends IBlockStub> extends StartStopService {
                 this.processNewHead(observedBlock);
             }
         } catch (doh) {
-            this.logger.error(doh);
+            const error = doh as Error;
+            this.logger.error(`There was an error fetching blocks: ${error.message}`);
+            this.logger.error(error.stack!);
         }
     }
 }

--- a/src/blockMonitor/blockchainMachine.ts
+++ b/src/blockMonitor/blockchainMachine.ts
@@ -4,7 +4,7 @@ import { Component, AnchorState, ComponentAction } from "./component";
 
 interface ComponentAndStates {
     component: Component<AnchorState, IBlockStub, ComponentAction>;
-    states: WeakMap<IBlockStub, object>;
+    states: WeakMap<IBlockStub, AnchorState>;
 }
 
 // Generic class to handle the anchor statee of a blockchain state machine

--- a/src/blockMonitor/blockchainMachine.ts
+++ b/src/blockMonitor/blockchainMachine.ts
@@ -4,7 +4,7 @@ import { Component, AnchorState, ComponentAction } from "./component";
 
 interface ComponentAndStates {
     component: Component<AnchorState, IBlockStub, ComponentAction>;
-    states: WeakMap<IBlockStub, {}>;
+    states: WeakMap<IBlockStub, object>;
 }
 
 // Generic class to handle the anchor statee of a blockchain state machine
@@ -68,7 +68,7 @@ export class BlockchainMachine<TBlock extends IBlockStub> extends StartStopServi
 
         for (const { component, states } of this.componentsAndStates) {
             const state = states.get(head);
-            if (!state) {
+            if (state == undefined) {
                 // as processNewBlock is always called before processNewHead, this should never happen
                 this.logger.error(
                     `State for block ${head.hash} (number ${head.number}) was not set, but it should have been`

--- a/src/blockMonitor/blockchainMachine.ts
+++ b/src/blockMonitor/blockchainMachine.ts
@@ -70,16 +70,17 @@ export class BlockchainMachine<TBlock extends IBlockStub> extends StartStopServi
             const state = states.get(head);
             if (!state) {
                 // as processNewBlock is always called before processNewHead, this should never happen
-                throw new ApplicationError(
+                this.logger.error(
                     `State for block ${head.hash} (number ${head.number}) was not set, but it should have been`
                 );
+                return;
             }
             if (prevHead) {
                 const prevState = states.get(prevHead);
                 if (prevState) {
                     const actions = component.detectChanges(prevState, state);
                     // side effects must be thread safe, so we can execute them concurrently
-                    actions.forEach(a => component.applyAction(a))
+                    actions.forEach(a => component.applyAction(a));
                 }
             }
         }

--- a/src/blockMonitor/blockchainMachine.ts
+++ b/src/blockMonitor/blockchainMachine.ts
@@ -51,7 +51,7 @@ export class BlockchainMachine<TBlock extends IBlockStub> extends StartStopServi
             // Finally, if the parent is not available at all in the block cache, compute the initial state based on the current block.
 
             if (this.blockProcessor.blockCache.hasBlock(block.parentHash)) {
-                const parentBlock = this.blockProcessor.blockCache.getBlockStub(block.parentHash);
+                const parentBlock = this.blockProcessor.blockCache.getBlock(block.parentHash);
                 const prevAnchorState = states.get(parentBlock) || component.reducer.getInitialState(parentBlock);
 
                 states.set(block, component.reducer.reduce(prevAnchorState, block));

--- a/src/dataEntities/errors.ts
+++ b/src/dataEntities/errors.ts
@@ -107,33 +107,6 @@ export class ArgumentError extends ApplicationError {
 }
 
 /**
- * Thrown after some number of blocks has been mined while waiting for something to happen.
- */
-export class BlockThresholdReachedError extends ApplicationError {
-    constructor(message: string) {
-        super(message, undefined, "BlockThresholdReachedError");
-    }
-}
-/**
- * Thrown when no block has been received by the provider for too long.
- * This might signal either a failure in the provider, or abnormal blockchain conditions.
- */
-export class BlockTimeoutError extends ApplicationError {
-    constructor(message: string) {
-        super(message, undefined, "BlockTimeoutError");
-    }
-}
-
-/**
- * Thrown when there was a re-org.
- */
-export class ReorgError extends ApplicationError {
-    constructor(message: string) {
-        super(message, undefined, "ReorgError");
-    }
-}
-
-/**
  * Thrown when an inconsistency in a queue is observed.
  */
 export class QueueConsistencyError extends ApplicationError {

--- a/src/dataEntities/errors.ts
+++ b/src/dataEntities/errors.ts
@@ -62,6 +62,17 @@ export class TimeoutError extends ApplicationError {
 }
 
 /**
+ * Thrown when an attempt to fetch a block fails.
+ */
+export class BlockFetchingError extends ApplicationError {
+    constructor(message: string);
+    constructor(message: string, nestedError: Error);
+    constructor(message: string, nestedError?: Error) {
+        super(message, nestedError, "BlockFetchingError");
+    }
+}
+
+/**
  * Thrown when data does not match a specified format
  * Error messages must be safe to expose publicly
  */

--- a/src/dataEntities/index.ts
+++ b/src/dataEntities/index.ts
@@ -5,10 +5,7 @@ export {
     PublicDataValidationError,
     PublicInspectionError,
     ConfigurationError,
-    ApplicationError,
-    BlockThresholdReachedError,
-    BlockTimeoutError,
-    ReorgError
+    ApplicationError
 } from "./errors";
 export { StartStopService } from "./startStop";
 export { IBlockStub, TransactionHashes, Logs, Transactions, Block } from "./block";

--- a/test/src/blockMonitor/blockCache.test.ts
+++ b/test/src/blockMonitor/blockCache.test.ts
@@ -3,6 +3,7 @@ import { expect } from "chai";
 import { BlockCache, getConfirmations } from "../../../src/blockMonitor";
 import { ArgumentError, IBlockStub, TransactionHashes, ApplicationError } from "../../../src/dataEntities";
 import fnIt from "../../utils/fnIt";
+import { BlockAddResult } from "../../../src/blockMonitor/blockCache";
 
 function generateBlocks(
     nBlocks: number,
@@ -41,20 +42,20 @@ describe("BlockCache", () => {
         expect(blocks[0]).to.deep.include(bc.getBlock(blocks[0].hash));
     });
 
-    fnIt<BlockCache<any>>(b => b.addBlock, "addBlock adds blocks that are complete and returns true", () => {
+    fnIt<BlockCache<any>>(b => b.addBlock, "adds blocks that are complete and returns Added", () => {
         const bc = new BlockCache(maxDepth);
         const blocks = generateBlocks(10, 5, "main");
-        expect(bc.addBlock(blocks[0])).to.be.true;
-        expect(bc.addBlock(blocks[1])).to.be.true;
-        expect(bc.addBlock(blocks[2])).to.be.true;
+        expect(bc.addBlock(blocks[0])).to.equal(BlockAddResult.Added);
+        expect(bc.addBlock(blocks[1])).to.equal(BlockAddResult.Added);
+        expect(bc.addBlock(blocks[2])).to.equal(BlockAddResult.Added);
     });
 
     fnIt<BlockCache<any>>(b => b.addBlock, "adds pending blocks and returns false", () => {
         const bc = new BlockCache(maxDepth);
         const blocks = generateBlocks(10, 5, "main");
         bc.addBlock(blocks[0]);
-        expect(bc.addBlock(blocks[3])).to.be.false;
-        expect(bc.addBlock(blocks[2])).to.be.false;
+        expect(bc.addBlock(blocks[3])).to.equal(BlockAddResult.AddedDetached);
+        expect(bc.addBlock(blocks[2])).to.equal(BlockAddResult.AddedDetached);
     });
 
     fnIt<BlockCache<any>>(b => b.hasBlock, "returns true for an existing complete block", () => {
@@ -100,7 +101,7 @@ describe("BlockCache", () => {
             bc.addBlock(blocks[0]);
             bc.addBlock(blocks[3]);
             bc.addBlock(blocks[2]);
-            expect(bc.addBlock(blocks[1])).to.be.true;
+            expect(bc.addBlock(blocks[1])).to.equal(BlockAddResult.Added);
             expect(bc.maxHeight).to.equal(blocks[3].number);
             expect(bc.hasBlock(blocks[3].hash)).to.be.true;
         }

--- a/test/src/blockMonitor/blockCache.test.ts
+++ b/test/src/blockMonitor/blockCache.test.ts
@@ -181,7 +181,7 @@ describe("BlockCache", () => {
     });
 
     fnIt<BlockCache<any>>(
-        b => b.canAddBlock,
+        b => b.canAttachBlock,
         "returns true for blocks whose height is equal to the initial height",
         () => {
             const bc = new BlockCache(maxDepth);
@@ -191,13 +191,13 @@ describe("BlockCache", () => {
 
             bc.addBlock(blocks[3]);
 
-            expect(bc.canAddBlock(blocks[3])).to.be.true;
-            expect(bc.canAddBlock(otherBlocks[3])).to.be.true;
+            expect(bc.canAttachBlock(blocks[3])).to.be.true;
+            expect(bc.canAttachBlock(otherBlocks[3])).to.be.true;
         }
     );
 
     fnIt<BlockCache<any>>(
-        b => b.canAddBlock,
+        b => b.canAttachBlock,
         "returns false for blocks whose height is lower than the initial height",
         () => {
             const bc = new BlockCache(maxDepth);
@@ -207,13 +207,13 @@ describe("BlockCache", () => {
 
             bc.addBlock(blocks[3]);
 
-            expect(bc.canAddBlock(blocks[2])).to.be.false;
-            expect(bc.canAddBlock(otherBlocks[2])).to.be.false;
+            expect(bc.canAttachBlock(blocks[2])).to.be.false;
+            expect(bc.canAttachBlock(otherBlocks[2])).to.be.false;
         }
     );
 
     fnIt<BlockCache<any>>(
-        b => b.canAddBlock,
+        b => b.canAttachBlock,
         "returns true for a block whose height is equal to the maximum depth",
         () => {
             const bc = new BlockCache(maxDepth);
@@ -224,12 +224,12 @@ describe("BlockCache", () => {
 
             const otherBlocks = generateBlocks(2, initialHeight - 1, "main");
 
-            expect(bc.canAddBlock(otherBlocks[1])).to.be.true;
+            expect(bc.canAttachBlock(otherBlocks[1])).to.be.true;
         }
     );
 
     fnIt<BlockCache<any>>(
-        b => b.canAddBlock,
+        b => b.canAttachBlock,
         "returns false for blocks whose height is lower than the maximum depth",
         () => {
             const bc = new BlockCache(maxDepth);
@@ -240,21 +240,21 @@ describe("BlockCache", () => {
 
             const otherBlocks = generateBlocks(2, initialHeight - 1, "main");
 
-            expect(bc.canAddBlock(otherBlocks[0])).to.be.false;
+            expect(bc.canAttachBlock(otherBlocks[0])).to.be.false;
         }
     );
 
-    fnIt<BlockCache<any>>(b => b.canAddBlock, "returns true for a block whose parent is in the BlockCache", () => {
+    fnIt<BlockCache<any>>(b => b.canAttachBlock, "returns true for a block whose parent is in the BlockCache", () => {
         const bc = new BlockCache(maxDepth);
         const blocks = generateBlocks(10, 7, "main");
 
         bc.addBlock(blocks[5]);
 
-        expect(bc.canAddBlock(blocks[6])).to.be.true;
+        expect(bc.canAttachBlock(blocks[6])).to.be.true;
     });
 
     fnIt<BlockCache<any>>(
-        b => b.canAddBlock,
+        b => b.canAttachBlock,
         "returns false for a block above minHeight whose parent is not in the BlockCache",
         () => {
             const bc = new BlockCache(maxDepth);
@@ -264,7 +264,7 @@ describe("BlockCache", () => {
             bc.addBlock(blocks[1]);
             bc.addBlock(blocks[2]);
 
-            expect(bc.canAddBlock(blocks[4])).to.be.false;
+            expect(bc.canAttachBlock(blocks[4])).to.be.false;
         }
     );
 

--- a/test/src/blockMonitor/blockProcessor.test.ts
+++ b/test/src/blockMonitor/blockProcessor.test.ts
@@ -2,7 +2,7 @@ import "mocha";
 import * as chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { ethers } from "ethers";
-import { mock, when, instance, anything } from "ts-mockito";
+import { mock, when, anything } from "ts-mockito";
 import { EventEmitter } from "events";
 import { BlockProcessor, BlockCache, blockStubAndTxFactory } from "../../../src/blockMonitor";
 import { IBlockStub } from "../../../src/dataEntities";

--- a/test/src/blockMonitor/blockchainMachine.test.ts
+++ b/test/src/blockMonitor/blockchainMachine.test.ts
@@ -85,7 +85,7 @@ describe("BlockchainMachine", () => {
         await bm.stop();
     });
 
-    it(" processNewBlock computes the initial state if the parent is not in cache", async () => {
+    it("processNewBlock computes the initial state if the parent is not in cache", async () => {
         const bm = new BlockchainMachine(blockProcessor);
         bm.addComponent(new ExampleComponent(reducer));
         await bm.start();
@@ -226,22 +226,6 @@ describe("BlockchainMachine", () => {
         expect(prevState).to.deep.equal(initialState);
         expect(nextState).to.deep.equal(nextStateExpected);
         expect(actions).to.deep.equal({ prevState: initialState, newState: nextStateExpected });
-
-        await bm.stop();
-    });
-
-    it("processNewHead throws ApplicationError if the state was not computed for the current head", async () => {
-        const bm = new BlockchainMachine(blockProcessor);
-        const component = new ExampleComponent(reducer);
-
-        bm.addComponent(component);
-        await bm.start();
-
-        blockProcessor.emit(BlockProcessor.NEW_BLOCK_EVENT, blocks[0]);
-        blockProcessor.emit(BlockProcessor.NEW_HEAD_EVENT, blocks[0], null);
-
-        // We simulate a new_head without a new_block event (which is never expected to happen)
-        expect(() => blockProcessor.emit(BlockProcessor.NEW_HEAD_EVENT, blocks[1], blocks[0])).to.throw(ApplicationError); //prettier-ignore
 
         await bm.stop();
     });

--- a/test/src/serviceEndToEnd.test.ts
+++ b/test/src/serviceEndToEnd.test.ts
@@ -190,10 +190,10 @@ describe("Service end-to-end", () => {
 
         // now register a callback on the setstate event and trigger a response
         const setStateEvent = "EventEvidence(uint256, bytes32)";
-        let successResult = { success: false };
+        let success = false;
         channelContract.on(setStateEvent, () => {
             channelContract.removeAllListeners(setStateEvent);
-            successResult.success = true;
+            success = true;
         });
 
         // trigger a dispute
@@ -202,7 +202,7 @@ describe("Service end-to-end", () => {
 
         try {
             // wait for the success result
-            await waitForPredicate(successResult, s => s.success, 400);
+            await waitForPredicate(() => success, 50, 20);
         } catch (doh) {
             // fail if we dont get it
             chai.assert.fail(true, false, "EventEvidence not successfully registered.");
@@ -229,10 +229,10 @@ describe("Service end-to-end", () => {
 
         // now register a callback on the setstate event and trigger a response
         const setStateEvent = "EventEvidence(uint256, bytes32)";
-        let successResult = { success: false };
+        let success = false;
         channelContract.on(setStateEvent, () => {
             channelContract.removeAllListeners(setStateEvent);
-            successResult.success = true;
+            success = true;
         });
 
         // trigger a dispute
@@ -241,7 +241,7 @@ describe("Service end-to-end", () => {
 
         try {
             // wait for the success result
-            await waitForPredicate(successResult, s => s.success, 400);
+            await waitForPredicate(() => success, 50, 20);
         } catch (doh) {
             // fail if we dont get it
             chai.assert.fail(true, false, "EventEvidence not successfully registered.");
@@ -258,15 +258,15 @@ describe("Service end-to-end", () => {
 
         // now register a callback on the setstate event and trigger a response
         const triggerDisputeEvent = "EventDispute(uint256)";
-        let successResult = { success: false };
+        let success = false;
         oneWayChannelContract.on(triggerDisputeEvent, async () => {
             oneWayChannelContract.removeAllListeners(triggerDisputeEvent);
-            successResult.success = true;
+            success = true;
         });
 
         try {
             // wait for the success result
-            await waitForPredicate(successResult, s => s.success, 200);
+            await waitForPredicate(() => success, 50, 20);
         } catch (doh) {
             // fail if we dont get it
             chai.assert.fail(true, false, "EventEvidence not successfully registered.");
@@ -288,15 +288,15 @@ describe("Service end-to-end", () => {
 
         // now register a callback on the setstate event and trigger a response
         const triggerDisputeEvent = "EventDispute(uint256)";
-        let successResult = { success: false };
+        let success = false;
         oneWayChannelContract.on(triggerDisputeEvent, async () => {
             oneWayChannelContract.removeAllListeners(triggerDisputeEvent);
-            successResult.success = true;
+            success = true;
         });
 
         try {
             // wait for the success result
-            await waitForPredicate(successResult, s => s.success, 200);
+            await waitForPredicate(() => success, 50, 20);
         } catch (doh) {
             // fail if we dont get it
             chai.assert.fail(true, false, "EventEvidence not successfully registered.");
@@ -661,15 +661,16 @@ describe("Service end-to-end", () => {
     };
 });
 
-// assess the value of a predicate after a timeout, throws if predicate does not evaluate to true
-const waitForPredicate = <T1>(successResult: T1, predicate: (a: T1) => boolean, timeout: number) => {
+// assess the value of a predicate every `interval` milliseconds, resolves if predicate evaluates to true; rejects after `repetitions` failed attempts
+const waitForPredicate = <T1>(predicate: () => boolean, interval: number, repetitions: number) => {
     return new Promise((resolve, reject) => {
-        setTimeout(() => {
-            if (predicate(successResult)) {
+        const intervalHandle = setInterval(() => {
+            if (predicate()) {
                 resolve();
-            } else {
+                clearInterval(intervalHandle);
+            } else if (--repetitions <= 0) {
                 reject();
             }
-        }, timeout);
+        }, interval);
     });
 };


### PR DESCRIPTION
1. Modified the `BlockCache` to also allow adding blocks before adding their parent. Those blocks are considered _pending_ and kept in a separate structure. `getBlock` will return a known block regardless if it's pending, while `hasBlock` allow to specify if pending blocks should be considered or not. The addition of pending blocks allows to simplify the BlockProcessor's logic, at the cost of some more complexity in the BlockCache, as I added some non-trivial logic to make "pending" block become _complete_ as soon as possible, while staying close to computationally optimal.
2. The BlockProcessor now adds blocks (possibly as _pending_) as soon as possible. Moreover, it now handles failures from `getBlock` either returning `null` or throwing an error (behaviors observed when running against Infura, see #227). The behavior I implemented is a **silent failure**, that is, it will give up processing the current head block, and wait until a new_head event from the provider, but previously downloaded blocks won't have to be downloaded again, as they are _pending_ in the cache.
3. The NEW_BLOCK event of the BlockProcessor, which is now re-emitting blocks that were already emitted in case of switching forks multiple times. To be more precise, all blocks between the latest emitted head in the ancestry and the current head are emitted in a NEW_BLOCK event. _**This is a semantic change**_ in how forks are handled. Another reasonable choice would be to only ever emit the same block once, even in case of multiple re-orgs. I currently don't have strong reasons to prefer one approach over the other (re-emitting blocks might allow to recompute the intermediate anchor states with fresh information; but it should not be a crucial difference imho).
4. On an unrelated note, I modified the `waitForPredicate` in serviceEndToEnd.test.ts so that it checks for the predicate many times instead of a fixed timeout, speeding up the unit tests quite a lot (and simultaneously incrementing the maximum timeouts for those tests, in order to reduce failures that I was observing on CircleCI).
5. Modified `BlockProcessor.processNewBlock` to skip processing a block that was already known in the cache; this was causing the problem in the integration tests mentioned below.