### PR TITLE
Added utility class for nested errors

### DIFF
--- a/src/dataEntities/errors.ts
+++ b/src/dataEntities/errors.ts
@@ -132,16 +132,18 @@ export class NestedError extends ApplicationError {
      *             Subclasses of `NestedError` should always pass their name.
      *             If not provided, the default value `"NestedError"` will be used.
      */
-    constructor(message: string, nestedError: Error, name: string = "NestedError") {
+    constructor(message: string, nestedError?: Error, name: string = "NestedError") {
         super(message);
 
         this.name = name;
 
-        // As the stack property is not standard (and browsers might differ in behavior compared to Node's implementation),
-        // we guard for its existence and keep the behavior simple.
-        if (nestedError.stack != undefined && this.stack != undefined) {
-            // Concatenate the stack traces
-            this.stack += "\nCaused by: " + nestedError.stack;
+        if (nestedError) {
+            // As the stack property is not standard (and browsers might differ in behavior compared to Node's implementation),
+            // we guard for its existence and keep the behavior simple.
+            if (nestedError.stack != undefined && this.stack != undefined) {
+                // Concatenate the stack traces
+                this.stack += "\nCaused by: " + nestedError.stack;
+            }
         }
     }
 }

--- a/src/dataEntities/errors.ts
+++ b/src/dataEntities/errors.ts
@@ -12,6 +12,9 @@ export class ApplicationError extends Error {
      *             Subclasses of `ApplicationError` should always pass their name.
      *             If not provided, the default value `"ApplicationError"` will be used.
      */
+    constructor(message: string);
+    constructor(message: string, nestedError: Error);
+    constructor(message: string, nestedError: Error | undefined, name: string);
     constructor(message: string, nestedError?: Error, name: string = "ApplicationError") {
         super(message);
 

--- a/src/dataEntities/errors.ts
+++ b/src/dataEntities/errors.ts
@@ -22,6 +22,36 @@ export class UnreachableCaseError extends ApplicationError {
 }
 
 /**
+ * Base class for errors that ar thrown when a deeper error cannot be handled.
+ * Customizes the stack trace in order to show the full stack trace of both the current
+ * error and the originating error.
+ */
+export class NestedError extends ApplicationError {
+    /**
+     *
+     * @param message The error message.
+     * @param nestedError The `Error` instance of the originating error.
+     * @param name The name of the error shown in the stack trace; the `name` property is set to this value.
+     *             Subclasses of `NestedError` should always pass their name.
+     *             If not provided, the default value `"NestedError"` will be used.
+     */
+    constructor(message: string, nestedError?: Error, name: string = "NestedError") {
+        super(message);
+
+        this.name = name;
+
+        if (nestedError) {
+            // As the stack property is not standard (and browsers might differ in behavior compared to Node's implementation),
+            // we guard for its existence and keep the behavior simple.
+            if (nestedError.stack != undefined && this.stack != undefined) {
+                // Concatenate the stack traces
+                this.stack += "\nCaused by: " + nestedError.stack;
+            }
+        }
+    }
+}
+
+/**
  * Thrown when startup configuration is incorrect.
  */
 export class ConfigurationError extends ApplicationError {
@@ -45,7 +75,7 @@ export class TimeoutError extends ApplicationError {
  * Thrown when data does not match a specified format
  * Error messages must be safe to expose publicly
  */
-export class PublicDataValidationError extends ApplicationError {
+export class PublicDataValidationError extends NestedError {
     constructor(message: string) {
         super(message);
         this.name = "PublicDataValidationError";
@@ -56,10 +86,9 @@ export class PublicDataValidationError extends ApplicationError {
  * Thrown when an appointment fails inspection
  * Error messages must be safe to expose publicly
  */
-export class PublicInspectionError extends ApplicationError {
-    constructor(message: string) {
-        super(message);
-        this.name = "PublicInspectionError";
+export class PublicInspectionError extends NestedError {
+    constructor(message: string, nestedError?: Error) {
+        super(message, nestedError, "PublicInspectionError");
     }
 }
 
@@ -115,35 +144,5 @@ export class QueueConsistencyError extends ApplicationError {
     constructor(message: string) {
         super(message);
         this.name = "QueueConsistencyError";
-    }
-}
-
-/**
- * Base class for errors that ar thrown when a deeper error cannot be handled.
- * Customizes the stack trace in order to show the full stack trace of both the current
- * error and the originating error.
- */
-export class NestedError extends ApplicationError {
-    /**
-     *
-     * @param message The error message.
-     * @param nestedError The `Error` instance of the originating error.
-     * @param name The name of the error shown in the stack trace; the `name` property is set to this value.
-     *             Subclasses of `NestedError` should always pass their name.
-     *             If not provided, the default value `"NestedError"` will be used.
-     */
-    constructor(message: string, nestedError?: Error, name: string = "NestedError") {
-        super(message);
-
-        this.name = name;
-
-        if (nestedError) {
-            // As the stack property is not standard (and browsers might differ in behavior compared to Node's implementation),
-            // we guard for its existence and keep the behavior simple.
-            if (nestedError.stack != undefined && this.stack != undefined) {
-                // Concatenate the stack traces
-                this.stack += "\nCaused by: " + nestedError.stack;
-            }
-        }
     }
 }

--- a/src/dataEntities/errors.ts
+++ b/src/dataEntities/errors.ts
@@ -117,3 +117,31 @@ export class QueueConsistencyError extends ApplicationError {
         this.name = "QueueConsistencyError";
     }
 }
+
+/**
+ * Base class for errors that ar thrown when a deeper error cannot be handled.
+ * Customizes the stack trace in order to show the full stack trace of both the current
+ * error and the originating error.
+ */
+export class NestedError extends Error {
+    /**
+     *
+     * @param message The error message.
+     * @param nestedError The `Error` instance of the originating error.
+     * @param name The name of the error shown in the stack trace; the `name` property is set to this value.
+     *             Subclasses of `NestedError` should always pass their name.
+     *             If not provided, the default value `"NestedError"` will be used.
+     */
+    constructor(message: string, nestedError: Error, name: string = "NestedError") {
+        super(message);
+
+        this.name = name;
+
+        // As the stack property is not standard (and browsers might differ in behavior compared to Node's implementation),
+        // we guard for its existence and keep the behavior simple.
+        if (nestedError.stack != undefined && this.stack != undefined) {
+            // Concatenate the stack traces
+            this.stack += "\nCaused by: " + nestedError.stack;
+        }
+    }
+}

--- a/src/dataEntities/errors.ts
+++ b/src/dataEntities/errors.ts
@@ -1,41 +1,18 @@
 /**
- * An error thrown by the application.
+ * Base class for errors thrown by the application.
+ * If a `nestedError` is given, it customizes the stacktrace in order to also show
+ * the full stack trace of the originating error.
  */
 export class ApplicationError extends Error {
-    constructor(message: string) {
-        super(message);
-        this.name = "ApplicationError";
-    }
-}
-
-/**
- * Thrown when code that is not supposed to be reached was actually reached. It can be used to make sure that a series of if-then-else or
- * cases in a switch statement over an enum or union types is exhaustive, in a type-safe way.
- * Errors of this kind represent a bug.
- */
-export class UnreachableCaseError extends ApplicationError {
-    constructor(val: never, message?: string) {
-        const msg = `Unreachable code: ${val}`;
-        super(message ? `${message} ${msg}` : msg);
-        this.name = "UnreachableCaseError";
-    }
-}
-
-/**
- * Base class for errors that ar thrown when a deeper error cannot be handled.
- * Customizes the stack trace in order to show the full stack trace of both the current
- * error and the originating error.
- */
-export class NestedError extends ApplicationError {
     /**
      *
      * @param message The error message.
-     * @param nestedError The `Error` instance of the originating error.
+     * @param nestedError Optionally, the `Error` instance of the originating error.
      * @param name The name of the error shown in the stack trace; the `name` property is set to this value.
-     *             Subclasses of `NestedError` should always pass their name.
-     *             If not provided, the default value `"NestedError"` will be used.
+     *             Subclasses of `ApplicationError` should always pass their name.
+     *             If not provided, the default value `"ApplicationError"` will be used.
      */
-    constructor(message: string, nestedError?: Error, name: string = "NestedError") {
+    constructor(message: string, nestedError?: Error, name: string = "ApplicationError") {
         super(message);
 
         this.name = name;
@@ -52,12 +29,23 @@ export class NestedError extends ApplicationError {
 }
 
 /**
+ * Thrown when code that is not supposed to be reached was actually reached. It can be used to make sure that a series of if-then-else or
+ * cases in a switch statement over an enum or union types is exhaustive, in a type-safe way.
+ * Errors of this kind represent a bug.
+ */
+export class UnreachableCaseError extends ApplicationError {
+    constructor(val: never, message?: string) {
+        const msg = `Unreachable code: ${val}`;
+        super(message ? `${message} ${msg}` : msg, undefined, "UnreachableCaseError");
+    }
+}
+
+/**
  * Thrown when startup configuration is incorrect.
  */
 export class ConfigurationError extends ApplicationError {
     constructor(message: string) {
-        super(message);
-        this.name = "ConfigurationError";
+        super(message, undefined, "ConfigurationError");
     }
 }
 
@@ -66,8 +54,7 @@ export class ConfigurationError extends ApplicationError {
  **/
 export class TimeoutError extends ApplicationError {
     constructor(message: string) {
-        super(message);
-        this.name = "TimeoutError";
+        super(message, undefined, "TimeoutError");
     }
 }
 
@@ -75,10 +62,9 @@ export class TimeoutError extends ApplicationError {
  * Thrown when data does not match a specified format
  * Error messages must be safe to expose publicly
  */
-export class PublicDataValidationError extends NestedError {
+export class PublicDataValidationError extends ApplicationError {
     constructor(message: string) {
-        super(message);
-        this.name = "PublicDataValidationError";
+        super(message, undefined, "PublicDataValidationError");
     }
 }
 
@@ -86,7 +72,7 @@ export class PublicDataValidationError extends NestedError {
  * Thrown when an appointment fails inspection
  * Error messages must be safe to expose publicly
  */
-export class PublicInspectionError extends NestedError {
+export class PublicInspectionError extends ApplicationError {
     constructor(message: string, nestedError?: Error) {
         super(message, nestedError, "PublicInspectionError");
     }
@@ -101,19 +87,17 @@ export class ArgumentError extends ApplicationError {
     constructor(message: string);
     constructor(message: string, ...args: any[]);
     constructor(message: string, ...args: any[]) {
-        super(message);
+        super(message, undefined, "ArgumentError");
         this.args = args;
-        this.name = "ArgumentError";
     }
 }
 
 /**
  * Thrown after some number of blocks has been mined while waiting for something to happen.
  */
-export class BlockThresholdReachedError extends Error {
+export class BlockThresholdReachedError extends ApplicationError {
     constructor(message: string) {
-        super(message);
-        this.name = "BlockThresholdReachedError";
+        super(message, undefined, "BlockThresholdReachedError");
     }
 }
 /**
@@ -122,8 +106,7 @@ export class BlockThresholdReachedError extends Error {
  */
 export class BlockTimeoutError extends ApplicationError {
     constructor(message: string) {
-        super(message);
-        this.name = "BlockTimeoutError";
+        super(message, undefined, "BlockTimeoutError");
     }
 }
 
@@ -132,8 +115,7 @@ export class BlockTimeoutError extends ApplicationError {
  */
 export class ReorgError extends ApplicationError {
     constructor(message: string) {
-        super(message);
-        this.name = "ReorgError";
+        super(message, undefined, "ReorgError");
     }
 }
 
@@ -142,7 +124,6 @@ export class ReorgError extends ApplicationError {
  */
 export class QueueConsistencyError extends ApplicationError {
     constructor(message: string) {
-        super(message);
-        this.name = "QueueConsistencyError";
+        super(message, undefined, "QueueConsistencyError");
     }
 }

--- a/src/dataEntities/errors.ts
+++ b/src/dataEntities/errors.ts
@@ -34,7 +34,7 @@ export class ConfigurationError extends ApplicationError {
 /**
  * Thrown when an event times out.
  **/
-export class TimeoutError extends Error {
+export class TimeoutError extends ApplicationError {
     constructor(message: string) {
         super(message);
         this.name = "TimeoutError";
@@ -91,7 +91,7 @@ export class BlockThresholdReachedError extends Error {
  * Thrown when no block has been received by the provider for too long.
  * This might signal either a failure in the provider, or abnormal blockchain conditions.
  */
-export class BlockTimeoutError extends Error {
+export class BlockTimeoutError extends ApplicationError {
     constructor(message: string) {
         super(message);
         this.name = "BlockTimeoutError";
@@ -101,7 +101,7 @@ export class BlockTimeoutError extends Error {
 /**
  * Thrown when there was a re-org.
  */
-export class ReorgError extends Error {
+export class ReorgError extends ApplicationError {
     constructor(message: string) {
         super(message);
         this.name = "ReorgError";
@@ -123,7 +123,7 @@ export class QueueConsistencyError extends ApplicationError {
  * Customizes the stack trace in order to show the full stack trace of both the current
  * error and the originating error.
  */
-export class NestedError extends Error {
+export class NestedError extends ApplicationError {
     /**
      *
      * @param message The error message.

--- a/src/responder/multiResponder.ts
+++ b/src/responder/multiResponder.ts
@@ -24,7 +24,7 @@ export class MultiResponder {
     public get transactions() {
         return this.zStore.transactions;
     }
-    
+
     /**
      * Can handle multiple response for a given signer. This responder requires exclusive
      * use of the signer, as it carefully manages the nonces of the transactions created by
@@ -87,7 +87,7 @@ export class MultiResponder {
 
             // we rethrow to the public if this item is already enqueued.
             if (doh instanceof GasQueueError && doh.kind === GasQueueErrorKind.AlreadyAdded) {
-                throw new PublicInspectionError(`Appointment already in queue.`);
+                throw new PublicInspectionError(`Appointment already in queue.`, doh);
             }
         }
     }
@@ -215,10 +215,10 @@ export class MultiResponder {
      * Checks to see if the responder balance is lower than the threshold set in the constructor.
      * If the balance is lower, a warning will be outputted by the logger
      */
-    public async checkBalance(){
+    public async checkBalance() {
         const currentBalance = await this.signer.provider!.getBalance(this.address);
-        if(currentBalance.lt(this.balanceThreshold)){
-            logger.error("Responder balance is becoming low. Current balance: "+ currentBalance);
-         }
+        if (currentBalance.lt(this.balanceThreshold)) {
+            logger.error("Responder balance is becoming low. Current balance: " + currentBalance);
+        }
     }
 }


### PR DESCRIPTION
Keeping it simple. Example of subclass:

```
class TestError extends NestedError {
    constructor(message: string, nestedError: Error) {
        super(message, nestedError, "TestError");
    }
}

const err = new TestError("An unexpected test error occurred.", new Error("Oh no!"));
```

Calling `toString()` (eg. `console.log(err)` above) prints it like this:

```
{ TestError: An unexpected test error occurred.
    at Object.<anonymous> (/home/spider/prog/pisa/test/src/dataEntities/appointment.test.ts:45:11)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
        [... omitted ...]
    at startup (internal/bootstrap/node.js:283:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:622:3)
Caused by: Error: Oh no!
    at Object.<anonymous> (/home/spider/prog/pisa/test/src/dataEntities/appointment.test.ts:45:63)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
        [... omitted ...]
    at startup (internal/bootstrap/node.js:283:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:622:3) name: 'TestError' }
```

Logs (e.g. `logger.info(err, "There was a nested error")`) don't look very pretty, but just because they are currently printed in JSON, like this:

```
{"name":"app","hostname":"spider-inspiron","pid":28539,"level":30,"err":{"message":"An unexpected test error occurred.","name":"TestError","stack":<omitted>},"msg":"There was a nested error","time":"2019-08-16T04:37:38.504Z","v":0}
```

Since the `stack` property of `Error` is not JS standard, I added guards for the existence; keeping the usage very simple should guarantee that it works with any reasonable implementation.