### PR TITLE
121 error when startstopservice not started

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2162,7 +2162,6 @@
           "version": "1.3.5",
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
           "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
-          "optional": true,
           "requires": {
             "mime-types": "~2.1.18",
             "negotiator": "0.6.1"
@@ -2238,8 +2237,7 @@
         "any-promise": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-          "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
-          "optional": true
+          "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
         },
         "anymatch": {
           "version": "2.0.0",
@@ -2291,8 +2289,7 @@
         "array-flatten": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-          "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
-          "optional": true
+          "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
         },
         "array-union": {
           "version": "1.0.2",
@@ -3163,7 +3160,6 @@
           "version": "1.2.2",
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
           "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
-          "optional": true,
           "requires": {
             "readable-stream": "^2.3.5",
             "safe-buffer": "^5.1.1"
@@ -3192,7 +3188,6 @@
           "version": "1.18.3",
           "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
           "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
-          "optional": true,
           "requires": {
             "bytes": "3.0.0",
             "content-type": "~1.0.4",
@@ -3210,7 +3205,6 @@
               "version": "2.6.9",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -3388,7 +3382,6 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
           "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-          "optional": true,
           "requires": {
             "buffer-alloc-unsafe": "^1.1.0",
             "buffer-fill": "^1.0.0"
@@ -3397,8 +3390,7 @@
         "buffer-alloc-unsafe": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-          "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-          "optional": true
+          "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
         },
         "buffer-crc32": {
           "version": "0.2.13",
@@ -3409,8 +3401,7 @@
         "buffer-fill": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-          "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
-          "optional": true
+          "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
         },
         "buffer-from": {
           "version": "1.1.1",
@@ -3420,8 +3411,7 @@
         "buffer-to-arraybuffer": {
           "version": "0.0.5",
           "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
-          "integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo=",
-          "optional": true
+          "integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo="
         },
         "buffer-xor": {
           "version": "1.0.3",
@@ -3436,8 +3426,7 @@
         "bytes": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
-          "optional": true
+          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
         },
         "bytewise": {
           "version": "1.1.0",
@@ -3819,14 +3808,12 @@
         "content-disposition": {
           "version": "0.5.2",
           "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-          "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
-          "optional": true
+          "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
         },
         "content-type": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-          "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-          "optional": true
+          "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
         },
         "convert-source-map": {
           "version": "1.6.0",
@@ -3839,20 +3826,17 @@
         "cookie": {
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
-          "optional": true
+          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
         },
         "cookie-signature": {
           "version": "1.0.6",
           "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-          "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
-          "optional": true
+          "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
         },
         "cookiejar": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
-          "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
-          "optional": true
+          "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
         },
         "copy-concurrently": {
           "version": "1.0.5",
@@ -3886,7 +3870,6 @@
           "version": "2.8.5",
           "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
           "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-          "optional": true,
           "requires": {
             "object-assign": "^4",
             "vary": "^1"
@@ -4093,7 +4076,6 @@
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
           "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-          "optional": true,
           "requires": {
             "mimic-response": "^1.0.0"
           }
@@ -4102,7 +4084,6 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
           "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
-          "optional": true,
           "requires": {
             "file-type": "^5.2.0",
             "is-stream": "^1.1.0",
@@ -4295,8 +4276,7 @@
         "depd": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-          "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-          "optional": true
+          "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
         },
         "des.js": {
           "version": "1.0.0",
@@ -4310,8 +4290,7 @@
         "destroy": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-          "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-          "optional": true
+          "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
         },
         "detect-indent": {
           "version": "4.0.0",
@@ -4367,8 +4346,7 @@
         "duplexer3": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-          "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-          "optional": true
+          "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
         },
         "duplexify": {
           "version": "3.7.1",
@@ -4393,8 +4371,7 @@
         "ee-first": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-          "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-          "optional": true
+          "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
         },
         "electron-to-chromium": {
           "version": "1.3.113",
@@ -4433,8 +4410,7 @@
         "encodeurl": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-          "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-          "optional": true
+          "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
         },
         "encoding": {
           "version": "0.1.12",
@@ -4533,8 +4509,7 @@
         "escape-html": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-          "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-          "optional": true
+          "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
         },
         "escape-string-regexp": {
           "version": "1.0.5",
@@ -4892,8 +4867,7 @@
         "etag": {
           "version": "1.8.1",
           "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-          "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-          "optional": true
+          "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
         },
         "eth-block-tracker": {
           "version": "3.0.1",
@@ -4971,7 +4945,6 @@
           "version": "0.1.27",
           "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
           "integrity": "sha512-B8czsfkJYzn2UIEMwjc7Mbj+Cy72V+/OXH/tb44LV8jhrjizQJJ325xMOMyk3+ETa6r6oi0jsUY14+om8mQMWA==",
-          "optional": true,
           "requires": {
             "bn.js": "^4.11.6",
             "elliptic": "^6.4.0",
@@ -5060,7 +5033,7 @@
               "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
               "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
               "requires": {
-                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#572d4bafe08a8a231137e1f9daeb0f8a23f197d2",
                 "ethereumjs-util": "^5.1.1"
               },
               "dependencies": {
@@ -5488,7 +5461,6 @@
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
           "integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
-          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "number-to-bn": "1.7.0"
@@ -5497,8 +5469,7 @@
             "bn.js": {
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "optional": true
+              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
             }
           }
         },
@@ -5514,8 +5485,7 @@
         "eventemitter3": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
-          "integrity": "sha1-R3hr2qCHyvext15zq8XH1UAVjNA=",
-          "optional": true
+          "integrity": "sha1-R3hr2qCHyvext15zq8XH1UAVjNA="
         },
         "events": {
           "version": "3.0.0",
@@ -5599,7 +5569,6 @@
           "version": "4.16.4",
           "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
           "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
-          "optional": true,
           "requires": {
             "accepts": "~1.3.5",
             "array-flatten": "1.1.1",
@@ -5637,7 +5606,6 @@
               "version": "2.6.9",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -5645,8 +5613,7 @@
             "statuses": {
               "version": "1.4.0",
               "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-              "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-              "optional": true
+              "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
             }
           }
         },
@@ -5829,8 +5796,7 @@
         "file-type": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
-          "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
-          "optional": true
+          "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
         },
         "file-uri-to-path": {
           "version": "1.0.0",
@@ -5867,7 +5833,6 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
           "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
-          "optional": true,
           "requires": {
             "debug": "2.6.9",
             "encodeurl": "~1.0.2",
@@ -5882,7 +5847,6 @@
               "version": "2.6.9",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -5890,8 +5854,7 @@
             "statuses": {
               "version": "1.4.0",
               "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-              "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-              "optional": true
+              "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
             }
           }
         },
@@ -5975,8 +5938,7 @@
         "forwarded": {
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-          "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
-          "optional": true
+          "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
         },
         "fragment-cache": {
           "version": "0.2.1",
@@ -5989,8 +5951,7 @@
         "fresh": {
           "version": "0.5.2",
           "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-          "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-          "optional": true
+          "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
         },
         "from2": {
           "version": "2.3.0",
@@ -6004,14 +5965,12 @@
         "fs-constants": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-          "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-          "optional": true
+          "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
         },
         "fs-extra": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
           "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
-          "optional": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "jsonfile": "^2.1.0"
@@ -6530,7 +6489,6 @@
           "version": "1.0.11",
           "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
           "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-          "optional": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "inherits": "~2.0.0",
@@ -6576,8 +6534,7 @@
         "get-stream": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-          "optional": true
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
         },
         "get-value": {
           "version": "2.0.6",
@@ -6666,7 +6623,6 @@
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
           "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
-          "optional": true,
           "requires": {
             "decompress-response": "^3.2.0",
             "duplexer3": "^0.1.4",
@@ -6737,8 +6693,7 @@
         "has-symbol-support-x": {
           "version": "1.4.2",
           "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
-          "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
-          "optional": true
+          "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
         },
         "has-symbols": {
           "version": "1.0.0",
@@ -6749,7 +6704,6 @@
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
           "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
-          "optional": true,
           "requires": {
             "has-symbol-support-x": "^1.4.1"
           }
@@ -6850,7 +6804,6 @@
           "version": "1.6.3",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-          "optional": true,
           "requires": {
             "depd": "~1.1.2",
             "inherits": "2.0.3",
@@ -6861,8 +6814,7 @@
         "http-https": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
-          "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs=",
-          "optional": true
+          "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs="
         },
         "http-signature": {
           "version": "1.2.0",
@@ -7186,8 +7138,7 @@
         "ipaddr.js": {
           "version": "1.8.0",
           "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
-          "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4=",
-          "optional": true
+          "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
         },
         "is-accessor-descriptor": {
           "version": "0.1.6",
@@ -7364,8 +7315,7 @@
         "is-object": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-          "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
-          "optional": true
+          "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
         },
         "is-observable": {
           "version": "1.1.0",
@@ -7399,8 +7349,7 @@
         "is-plain-obj": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-          "optional": true
+          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
         },
         "is-plain-object": {
           "version": "2.0.4",
@@ -7436,8 +7385,7 @@
         "is-retry-allowed": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-          "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-          "optional": true
+          "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
         },
         "is-stream": {
           "version": "1.1.0",
@@ -7517,7 +7465,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
           "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
-          "optional": true,
           "requires": {
             "has-to-string-tag-x": "^1.2.0",
             "is-object": "^1.0.1"
@@ -8218,8 +8165,7 @@
         "lowercase-keys": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-          "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-          "optional": true
+          "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
         },
         "lru-cache": {
           "version": "3.2.0",
@@ -8296,8 +8242,7 @@
         "media-typer": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-          "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-          "optional": true
+          "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
         },
         "mem": {
           "version": "4.1.0",
@@ -8349,8 +8294,7 @@
         "merge-descriptors": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-          "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-          "optional": true
+          "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
         },
         "merkle-patricia-tree": {
           "version": "2.3.1",
@@ -8411,8 +8355,7 @@
         "methods": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-          "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-          "optional": true
+          "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
         },
         "micromatch": {
           "version": "3.1.10",
@@ -8446,8 +8389,7 @@
         "mime": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
-          "optional": true
+          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
         },
         "mime-db": {
           "version": "1.38.0",
@@ -8470,8 +8412,7 @@
         "mimic-response": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-          "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-          "optional": true
+          "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
         },
         "min-document": {
           "version": "2.19.0",
@@ -8673,8 +8614,7 @@
         "nano-json-stream-parser": {
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
-          "integrity": "sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18=",
-          "optional": true
+          "integrity": "sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18="
         },
         "nanomatch": {
           "version": "1.2.13",
@@ -8702,8 +8642,7 @@
         "negotiator": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-          "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
-          "optional": true
+          "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
         },
         "neo-async": {
           "version": "2.6.0",
@@ -8851,7 +8790,6 @@
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
           "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
-          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "strip-hex-prefix": "1.0.0"
@@ -8860,8 +8798,7 @@
             "bn.js": {
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "optional": true
+              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
             }
           }
         },
@@ -9829,7 +9766,6 @@
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.3.tgz",
           "integrity": "sha1-K0hl29Rr6BIlcT9Om/5Lz09oCk8=",
-          "optional": true,
           "requires": {
             "http-https": "^1.0.0"
           }
@@ -9838,7 +9774,6 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-          "optional": true,
           "requires": {
             "ee-first": "1.1.1"
           }
@@ -9898,8 +9833,7 @@
         "p-cancelable": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-          "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
-          "optional": true
+          "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
         },
         "p-defer": {
           "version": "1.0.0",
@@ -9941,7 +9875,6 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
           "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
-          "optional": true,
           "requires": {
             "p-finally": "^1.0.0"
           }
@@ -9999,8 +9932,7 @@
         "parseurl": {
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-          "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
-          "optional": true
+          "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
         },
         "pascalcase": {
           "version": "0.1.1",
@@ -10048,8 +9980,7 @@
         "path-to-regexp": {
           "version": "0.1.7",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
-          "optional": true
+          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
         },
         "path-type": {
           "version": "1.1.0",
@@ -10183,8 +10114,7 @@
         "prepend-http": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-          "optional": true
+          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
         },
         "prettier": {
           "version": "1.16.4",
@@ -10234,7 +10164,6 @@
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
           "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
-          "optional": true,
           "requires": {
             "forwarded": "~0.1.2",
             "ipaddr.js": "1.8.0"
@@ -10363,7 +10292,6 @@
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
-          "optional": true,
           "requires": {
             "decode-uri-component": "^0.2.0",
             "object-assign": "^4.1.0",
@@ -10400,20 +10328,17 @@
         "randomhex": {
           "version": "0.1.5",
           "resolved": "https://registry.npmjs.org/randomhex/-/randomhex-0.1.5.tgz",
-          "integrity": "sha1-us7vmCMpCRQA8qKRLGzQLxCU9YU=",
-          "optional": true
+          "integrity": "sha1-us7vmCMpCRQA8qKRLGzQLxCU9YU="
         },
         "range-parser": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-          "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
-          "optional": true
+          "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
         },
         "raw-body": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
           "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
-          "optional": true,
           "requires": {
             "bytes": "3.0.0",
             "http-errors": "1.6.3",
@@ -10840,7 +10765,6 @@
           "version": "0.16.2",
           "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
           "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
-          "optional": true,
           "requires": {
             "debug": "2.6.9",
             "depd": "~1.1.2",
@@ -10861,7 +10785,6 @@
               "version": "2.6.9",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -10869,8 +10792,7 @@
             "statuses": {
               "version": "1.4.0",
               "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-              "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-              "optional": true
+              "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
             }
           }
         },
@@ -10883,7 +10805,6 @@
           "version": "1.13.2",
           "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
           "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
-          "optional": true,
           "requires": {
             "encodeurl": "~1.0.2",
             "escape-html": "~1.0.3",
@@ -10895,7 +10816,6 @@
           "version": "0.1.12",
           "resolved": "https://registry.npmjs.org/servify/-/servify-0.1.12.tgz",
           "integrity": "sha512-/xE6GvsKKqyo1BAY+KxOWXcLpPsUUyji7Qg3bVD7hh1eRze5bR1uYiuDA/k3Gof1s9BTzQZEJK8sNcNGFIzeWw==",
-          "optional": true,
           "requires": {
             "body-parser": "^1.16.0",
             "cors": "^2.8.1",
@@ -10943,8 +10863,7 @@
         "setprototypeof": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-          "optional": true
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
         },
         "sha.js": {
           "version": "2.4.11",
@@ -10984,14 +10903,12 @@
         "simple-concat": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-          "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
-          "optional": true
+          "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
         },
         "simple-get": {
           "version": "2.8.1",
           "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
           "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
-          "optional": true,
           "requires": {
             "decompress-response": "^3.3.0",
             "once": "^1.3.1",
@@ -11315,8 +11232,7 @@
         "statuses": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-          "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-          "optional": true
+          "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
         },
         "stream-browserify": {
           "version": "2.0.2",
@@ -11372,8 +11288,7 @@
         "strict-uri-encode": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-          "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-          "optional": true
+          "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
         },
         "string-argv": {
           "version": "0.0.2",
@@ -11582,7 +11497,6 @@
           "version": "1.6.2",
           "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
           "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
-          "optional": true,
           "requires": {
             "bl": "^1.0.0",
             "buffer-alloc": "^1.2.0",
@@ -11639,7 +11553,6 @@
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
           "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
-          "optional": true,
           "requires": {
             "any-promise": "^1.0.0"
           }
@@ -11648,7 +11561,6 @@
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
           "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
-          "optional": true,
           "requires": {
             "thenify": ">= 3.1.0 < 4"
           }
@@ -11670,8 +11582,7 @@
         "timed-out": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-          "optional": true
+          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
         },
         "timers-browserify": {
           "version": "2.0.10",
@@ -11697,8 +11608,7 @@
         "to-buffer": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-          "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
-          "optional": true
+          "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
         },
         "to-fast-properties": {
           "version": "1.0.3",
@@ -11814,7 +11724,6 @@
           "version": "1.6.16",
           "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
           "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
-          "optional": true,
           "requires": {
             "media-typer": "0.3.0",
             "mime-types": "~2.1.18"
@@ -11885,8 +11794,7 @@
         "ultron": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-          "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
-          "optional": true
+          "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
         },
         "unbzip2-stream": {
           "version": "1.3.3",
@@ -11901,8 +11809,7 @@
         "underscore": {
           "version": "1.8.3",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-          "optional": true
+          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
         },
         "union-value": {
           "version": "1.0.0",
@@ -11960,8 +11867,7 @@
         "unpipe": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-          "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-          "optional": true
+          "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
         },
         "unset-value": {
           "version": "1.0.0",
@@ -12042,7 +11948,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
           "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-          "optional": true,
           "requires": {
             "prepend-http": "^1.0.1"
           }
@@ -12050,14 +11955,12 @@
         "url-set-query": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
-          "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk=",
-          "optional": true
+          "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk="
         },
         "url-to-options": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
-          "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
-          "optional": true
+          "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
         },
         "use": {
           "version": "3.1.1",
@@ -12093,8 +11996,7 @@
         "utils-merge": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-          "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
-          "optional": true
+          "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
         },
         "uuid": {
           "version": "3.3.2",
@@ -12118,8 +12020,7 @@
         "vary": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-          "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-          "optional": true
+          "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
         },
         "verror": {
           "version": "1.10.0",
@@ -12179,7 +12080,6 @@
           "version": "1.0.0-beta.35",
           "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.35.tgz",
           "integrity": "sha512-ayGavbgVk4KL9Y88Uv411fBJ0SVgVfKhKEBweKYzmP0zOqneMzWt6YsyD1n6kRvjAbqA0AfUPEOKyMNjcx2tjw==",
-          "optional": true,
           "requires": {
             "web3-core-helpers": "1.0.0-beta.35",
             "web3-core-method": "1.0.0-beta.35",
@@ -12191,7 +12091,6 @@
           "version": "1.0.0-beta.35",
           "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.35.tgz",
           "integrity": "sha512-APOu3sEsamyqWt//8o4yq9KF25/uqGm+pQShson/sC4gKzmfJB07fLo2ond0X30E8fIqAPeVCotPXQxGciGUmA==",
-          "optional": true,
           "requires": {
             "underscore": "1.8.3",
             "web3-eth-iban": "1.0.0-beta.35",
@@ -12202,7 +12101,6 @@
           "version": "1.0.0-beta.35",
           "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.35.tgz",
           "integrity": "sha512-jidImCide8q0GpfsO4L73qoHrbkeWgwU3uOH5DKtJtv0ccmG086knNMRgryb/o9ZgetDWLmDEsJnHjBSoIwcbA==",
-          "optional": true,
           "requires": {
             "underscore": "1.8.3",
             "web3-core-helpers": "1.0.0-beta.35",
@@ -12215,7 +12113,6 @@
           "version": "1.0.0-beta.35",
           "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.35.tgz",
           "integrity": "sha512-GvqXqKq07OmHuVi5uNRg6k79a1/CI0ViCC+EtNv4CORHtDRmYEt5Bvdv6z6FJEiaaQkD0lKbFwNhLxutx7HItw==",
-          "optional": true,
           "requires": {
             "any-promise": "1.3.0",
             "eventemitter3": "1.1.1"
@@ -12225,7 +12122,6 @@
           "version": "1.0.0-beta.35",
           "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.35.tgz",
           "integrity": "sha512-S+zW2h17ZZQU9oe3yaCJE0E7aJS4C3Kf4kGPDv+nXjW0gKhQQhgVhw1Doq/aYQGqNSWJp7f1VHkz5gQWwg6RRg==",
-          "optional": true,
           "requires": {
             "underscore": "1.8.3",
             "web3-core-helpers": "1.0.0-beta.35",
@@ -12238,7 +12134,6 @@
           "version": "1.0.0-beta.35",
           "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.35.tgz",
           "integrity": "sha512-gXzLrWvcGkGiWq1y33Z4Y80XI8XMrwowiQJkrPSjQ81K5PBKquOGwcMffLaKcwdmEy/NpsOXDeFo3eLE1Ghvvw==",
-          "optional": true,
           "requires": {
             "eventemitter3": "1.1.1",
             "underscore": "1.8.3",
@@ -12269,7 +12164,6 @@
           "version": "1.0.0-beta.35",
           "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.35.tgz",
           "integrity": "sha512-KUDC+EtFFYG8z01ZleKrASdjj327/rtWHzEt6RWsEj7bBa0bGp9nEh+nqdZx/Sdgz1O8tnfFzJlrRcXpfr1vGg==",
-          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "underscore": "1.8.3",
@@ -12280,8 +12174,7 @@
             "bn.js": {
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "optional": true
+              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
             }
           }
         },
@@ -12352,7 +12245,6 @@
           "version": "1.0.0-beta.35",
           "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.35.tgz",
           "integrity": "sha512-H5wkcNcAIc+h/WoDIKv7ZYmrM2Xqu3O7jBQl1IWo73EDVQji+AoB2i3J8tuwI1yZRInRwrfpI3Zuwuf54hXHmQ==",
-          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "web3-utils": "1.0.0-beta.35"
@@ -12361,8 +12253,7 @@
             "bn.js": {
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "optional": true
+              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
             }
           }
         },
@@ -12370,7 +12261,6 @@
           "version": "1.0.0-beta.35",
           "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.35.tgz",
           "integrity": "sha512-AcM9nnlxu7ZRRxPvkrFB9eLxMM4A2cPfj2aCg21Wb2EpMnhR+b/O1cT33k7ApRowoMpM+T9M8vx2oPNwXfaCOQ==",
-          "optional": true,
           "requires": {
             "web3-core": "1.0.0-beta.35",
             "web3-core-helpers": "1.0.0-beta.35",
@@ -12383,7 +12273,6 @@
           "version": "1.0.0-beta.35",
           "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.35.tgz",
           "integrity": "sha512-bbwaQ/KohGjIJ6HAKbZ6KrklCAaG6/B7hIbAbVLSFLxF+Yz9lmAgQYaDInpidpC/NLb3WOmcbRF+P77J4qMVIA==",
-          "optional": true,
           "requires": {
             "web3-core": "1.0.0-beta.35",
             "web3-core-method": "1.0.0-beta.35",
@@ -12422,7 +12311,7 @@
               "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
               "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
               "requires": {
-                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#572d4bafe08a8a231137e1f9daeb0f8a23f197d2",
                 "ethereumjs-util": "^5.1.1"
               },
               "dependencies": {
@@ -12490,7 +12379,6 @@
           "version": "1.0.0-beta.35",
           "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.35.tgz",
           "integrity": "sha512-DcIMFq52Fb08UpWyZ3ZlES6NsNqJnco4hBS/Ej6eOcASfuUayPI+GLkYVZsnF3cBYqlH+DOKuArcKSuIxK7jIA==",
-          "optional": true,
           "requires": {
             "web3-core-helpers": "1.0.0-beta.35",
             "xhr2-cookies": "1.1.0"
@@ -12500,7 +12388,6 @@
           "version": "1.0.0-beta.35",
           "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.35.tgz",
           "integrity": "sha512-iB0FG0HcpUnayfa8pn4guqEQ4Y1nrroi/jffdtQgFkrNt0sD3fMSwwC0AbmECqj3tDLl0e1slBR0RENll+ZF0g==",
-          "optional": true,
           "requires": {
             "oboe": "2.1.3",
             "underscore": "1.8.3",
@@ -12511,18 +12398,16 @@
           "version": "1.0.0-beta.35",
           "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.35.tgz",
           "integrity": "sha512-Cx64NgDStynKaUGDIIOfaCd0fZusL8h5avKTkdTjUu2aHhFJhZoVBGVLhoDtUaqZGWIZGcBJOoVf2JkGUOjDRQ==",
-          "optional": true,
           "requires": {
             "underscore": "1.8.3",
             "web3-core-helpers": "1.0.0-beta.35",
-            "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
+            "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
           },
           "dependencies": {
             "debug": {
               "version": "2.6.9",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -12530,7 +12415,6 @@
             "websocket": {
               "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
               "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
-              "optional": true,
               "requires": {
                 "debug": "^2.2.0",
                 "nan": "^2.3.3",
@@ -12556,7 +12440,6 @@
           "version": "1.0.0-beta.35",
           "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.35.tgz",
           "integrity": "sha512-Dq6f0SOKj3BDFRgOPnE6ALbzBDCKVIW8mKWVf7tGVhTDHf+wQaWwQSC3aArFSqdExB75BPBPyDpuMTNszhljpA==",
-          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "eth-lib": "0.1.27",
@@ -12570,14 +12453,12 @@
             "bn.js": {
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "optional": true
+              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
             },
             "utf8": {
               "version": "2.1.1",
               "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
-              "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g=",
-              "optional": true
+              "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g="
             }
           }
         },
@@ -12909,7 +12790,6 @@
           "version": "3.3.3",
           "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
           "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
-          "optional": true,
           "requires": {
             "async-limiter": "~1.0.0",
             "safe-buffer": "~5.1.0",
@@ -12931,7 +12811,6 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
           "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
-          "optional": true,
           "requires": {
             "buffer-to-arraybuffer": "^0.0.5",
             "object-assign": "^4.1.1",
@@ -12946,7 +12825,6 @@
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.2.tgz",
           "integrity": "sha1-NDxE0e53JrhkgGloLQ+EDIO0Jh0=",
-          "optional": true,
           "requires": {
             "xhr-request": "^1.0.1"
           }
@@ -12955,7 +12833,6 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
           "integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
-          "optional": true,
           "requires": {
             "cookiejar": "^2.1.1"
           }

--- a/src/dataEntities/startStop.ts
+++ b/src/dataEntities/startStop.ts
@@ -23,7 +23,7 @@ export abstract class StartStopService extends EventEmitter {
      */
     protected logger: Logger;
 
-    protected logVerbosityOfNotStartedError: number = 5;
+    protected logVerbosityOfNotStartedError: number = 1;
 
     /**
      * A service that requires starting and stopping.
@@ -151,9 +151,6 @@ export abstract class StartStopService extends EventEmitter {
 
                 if (isWithinConstructor())
                     return target[prop];
-
-                // Throw no notStarted errors at all - obvs remove this line!
-                return target[prop];
 
                 if ((instance.logVerbosityOfNotStartedError >= 4) && (prop==="on" || prop==="off"))
                     return logOnOffEvents (target[prop]);

--- a/src/dataEntities/startStop.ts
+++ b/src/dataEntities/startStop.ts
@@ -23,7 +23,7 @@ export abstract class StartStopService extends EventEmitter {
      */
     protected logger: Logger;
 
-    protected logVerbosityOfNotStartedError: number = 0;
+    protected logVerbosityOfNotStartedError: number = 5;
 
     /**
      * A service that requires starting and stopping.
@@ -152,6 +152,9 @@ export abstract class StartStopService extends EventEmitter {
                 if (isWithinConstructor())
                     return target[prop];
 
+                // Throw no notStarted errors at all - obvs remove this line!
+                return target[prop];
+
                 if ((instance.logVerbosityOfNotStartedError >= 4) && (prop==="on" || prop==="off"))
                     return logOnOffEvents (target[prop]);
 
@@ -161,7 +164,7 @@ export abstract class StartStopService extends EventEmitter {
 
 
         this.logger = createNamedLogger(name);
-        // return new Proxy(this,proxyHandler);
+        return new Proxy(this,proxyHandler);
     }
 
     protected callsLog : string[] = [];

--- a/src/dataEntities/startStop.ts
+++ b/src/dataEntities/startStop.ts
@@ -1,4 +1,4 @@
-import { ConfigurationError } from "./errors";
+import { ApplicationError, ConfigurationError } from "./errors";
 import { createNamedLogger, Logger } from "../logger";
 import { EventEmitter } from "events";
 
@@ -23,6 +23,8 @@ export abstract class StartStopService extends EventEmitter {
      */
     protected logger: Logger;
 
+    protected logVerbosityOfNotStartedError: number = 0;
+
     /**
      * A service that requires starting and stopping.
      * Whoever constructs this service must start it before using it.
@@ -32,6 +34,27 @@ export abstract class StartStopService extends EventEmitter {
      */
     protected constructor(protected readonly name: string) {
         super();
+        let instance = this;
+
+        function detailsOfNotStartedError (instance: any, prop : string) :string {
+            if (instance.logVerbosityOfNotStartedError) {
+                let message : string = `    `;
+                message += `\n  Attempt was: ${instance.constructor.name}.${prop}`;
+                if (instance.mStarted || instance.suppressNotStartedError)
+                    message += `\n  start states are: .mStarted: ${instance.mStarted}, called internally: ${instance.suppressNotStartedError>1 ? instance.suppressNotStartedError : !!instance.suppressNotStartedError}`
+                if (instance.callsLog.length>1)
+                    message += `\n  Previous get chain on instance was: ${instance.callsLog.join('; ')}`;
+                else
+                    message += `\n  No previous calls on this instance` ;
+                if (instance.callsLog.indexOf(' start') ===-1)
+                    message += `\n  Cannot find any previous call to start`;
+                if (instance.callsLog.indexOf(' stop') >-1)
+                    message += `\n  Found call to stop, previous to this call`;
+                return message;
+            }
+            return '';
+        };
+
 
         if (!/^[a-z0-9\-]+$/.test(name)) {
             throw new ConfigurationError(
@@ -39,13 +62,115 @@ export abstract class StartStopService extends EventEmitter {
             );
         }
 
+        let proxyHandler = {
+            construct (target: any, prop: string) {
+                throw new Error ('Should not have reached here! (startStopService.construct)');
+                // return asProtectedMethod (target[prop]) ();
+            },
+
+            /**
+            * If method called is a protected one, return the requested function, though wrapped in
+            * checking/ setting of the appropriate flag to avoid errors in the functions contained calls to public methods.
+            * If method called is a public one, return the unmodified function as normal only if
+            * that flag is set or service is started - else error.
+            **/
+            get (target: any, prop: string) {
+
+                /**
+                * protected methods are:
+                * startInternal; stopInternal; start; stop; They, and their internals, can use public methods without start having yet been called.
+                * For constructors, a different means is used to detect whether the requested method is called below a constructor.
+                * This function is NOT safe for general use, eg for constructors, as it does not return the return value of the
+                * wrapped function (due to async / await complexity).
+                */
+                function asProtectedMethod (targetMethod : Function) {
+                    return async function (...args: any[]) {
+                        instance.suppressNotStartedError++;
+                        await targetMethod.apply(this, args);
+                        instance.suppressNotStartedError--;
+                        // we return nothing here (or, rather an empty Promise)
+                    };
+                }
+
+                /**
+                 *  Throws, since it is currently only called when, otherwise, a notStarted Error would be reached.
+                 *  Unreachable return behaviour is to allow for turning the error on/ off
+                **/
+                function logOnOffEvents (targetMethod : Function) {
+                    return function (...args: any[]) {
+                        if (instance.logVerbosityOfNotStartedError)
+                            instance.callsLog.push (` "${args[0].toString()}"`);
+                        throw new ApplicationError (`Service not started.\n${detailsOfNotStartedError (instance, 'on/off')}`);
+                        const result = targetMethod.apply(this, args);
+                        return result;
+                    };
+                }
+
+                /* relies on error.stack which is still stage 1. In particular some JSs will not set it at construction of Error
+                 * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack
+                 * Unfortunately Function.caller is also non-standard and when standardised will be overly restrictive
+                 * https://tc39.es/ecma262/#sec-forbidden-extensions
+                 * And arguments.callee.caller is deprecated.
+                 */
+                function isWithinConstructor () : boolean {
+                    const anyErr : {[k: string]: any} = new Error;
+                    // this means notStartedError will never throw when run in JS not supporting Error.stack (or not setting stack on new Error).
+                    if (!anyErr.hasOwnProperty('stack'))
+                        return true;
+                        // throw new ApplicationError (`Tried to access new Error.stack, but not found. Maybe your JS doesn't support it`);
+                    const ownClassHallmark : string = `at new ${instance.constructor.name}`;
+                    const spyHallmark : string = `at new Spy`;
+                    const stack : string = anyErr.stack;
+                    return (stack.indexOf(ownClassHallmark) > -1 || stack.indexOf(spyHallmark) > -1);
+                };
+
+                if (instance.logVerbosityOfNotStartedError) {
+                    let toLog : string = '';
+                    if (instance.suppressNotStartedError)
+                          toLog += `(${instance.suppressNotStartedError})`;
+                    toLog += ` ${prop}`;
+                    if (isWithinConstructor())
+                          toLog +=  ` (within constructor of ${instance.constructor.name})`;
+                    instance.callsLog.push (toLog);
+                }
+
+                // Do not intercept these
+                if (typeof target[prop] !== 'function' || prop==='asProtectedMethod')
+                    return target[prop];
+
+                if (prop==='start' || prop==='stop' || prop==='startInternal' || prop==='stopInternal')
+                    return asProtectedMethod (target[prop]);
+
+                if (instance.mStarted || (instance.suppressNotStartedError >0) )
+                    return target[prop];
+
+                // Temporary - remove this!
+                const knownErrorsWillBeFixed = ['addComponent',''];
+                if (knownErrorsWillBeFixed.indexOf(prop) > -1)
+                    return target[prop];
+
+                if (isWithinConstructor())
+                    return target[prop];
+
+                if ((instance.logVerbosityOfNotStartedError >= 4) && (prop==="on" || prop==="off"))
+                    return logOnOffEvents (target[prop]);
+
+                throw new ApplicationError (`Service not started.${detailsOfNotStartedError (instance, prop)}`);
+            }
+        }
+
+
         this.logger = createNamedLogger(name);
+        // return new Proxy(this,proxyHandler);
     }
+
+    protected callsLog : string[] = [];
     private mStarted: boolean = false;
     public get started() {
         return this.mStarted;
     }
     private mStarting: boolean = false;
+    private suppressNotStartedError: number = 0;
 
     /**
      * Start this service

--- a/test/src/dataEntities/startStop.test.ts
+++ b/test/src/dataEntities/startStop.test.ts
@@ -88,4 +88,23 @@ describe("StartStop", () => {
         verify(spiedService.startInternal()).once();
         verify(spiedService.stopInternal()).once();
     });
+    
+    it("start must be called before emptyTestMethod", async () => {
+        const testService = new TestStartStop();
+        const spiedService = spy(testService);
+
+        // call testMethod without first calling start
+        try {
+            testService.emptyTestMethod();
+            assert.fail();
+        } catch (err) {
+            expect((err as Error).message.slice(0,20)).to.equal("Service not started.");
+        }
+
+        await testService.stop();
+
+        //the block event was only subscribed to once
+        verify(spiedService.startInternal()).once();
+        verify(spiedService.stopInternal()).once();
+    });
 });

--- a/test/src/dataEntities/startStop.test.ts
+++ b/test/src/dataEntities/startStop.test.ts
@@ -9,6 +9,7 @@ class TestStartStop extends StartStopService {
     }
     public async startInternal() {}
     public async stopInternal() {}
+    public async emptyTestMethod() {}
 }
 
 class ManualStartStop extends StartStopService {


### PR DESCRIPTION
#121 
`startStopService`'s constructor returns a proxy, on which:
`get` is transparent when getting reference to `startInternal`, `stopInternal`, `start` and `stop` methods; 
or also if the `startStopService` instance is started (as per internal property `mStarted`
or also if a flag `suppressNotStartedError` (currently number) is set and not unset by one of those methods;
(and thus if a different method called below one of those methods)

`construct` is differently intercepted, based on examining the stack trace of a `new Error` (not thrown)

Can throw a 'Service not started' instance of ApplicationError.
More detailed logging in the error is available, done manually depending on property `logVerbosityOfNotStartedError` of the class.

Test added in `startStop.test.ts` expecting `ApplicationError` with the string beginning  `'Service not started'` when the empty `emptyTestMethod` is called on an instance without previously calling `start`.

