### PR TITLE
Adding setting to Parity config in integration test to ensure transactions being mined simultaneously

### DIFF
--- a/test/integration/docker.ts
+++ b/test/integration/docker.ts
@@ -173,6 +173,8 @@ export class ParityContainer extends DockerContainer {
             validator.account,
             "--reseal-on-txs",
             "none",
+            "--reseal-min-period", // to make multiple transaction confirm at the same time
+            "0", // see https://github.com/wbwangk/parity-wiki/blob/master/Private-development-chain.md#customizing-the-development-chain
             "--usd-per-tx",
             "0"
         ];


### PR DESCRIPTION
Documentation is lacking, but [this](https://github.com/wbwangk/parity-wiki/blob/master/Private-development-chain.md#customizing-the-development-chain) suggests the `--reseal-min-period 0` parameter for parity to mine multiple transactions in the same block. (There is already the `--reseal-on-txs none` setting, whiich is probably also good to have for this situation).

Actually, even without the addition, I couldn't reproduce any failure on the integration test due to transactions not being in the same block (which is being tested for explicitly). So I would merge this commit and consider #318 closed, unless failures happen again in the future/