### PR TITLE
Added a custom class for type-safe events

### DIFF
--- a/src/blockMonitor/blockCache.ts
+++ b/src/blockMonitor/blockCache.ts
@@ -21,7 +21,7 @@ export type NewBlockListener<TBlock> = (block: TBlock) => Promise<void>;
  * This interface represents the read-only view of a BlockCache.
  */
 export interface ReadOnlyBlockCache<TBlock extends IBlockStub> {
-    NewBlock: BlockEvent<TBlock>;
+    newBlock: BlockEvent<TBlock>;
     readonly maxDepth: number;
     readonly maxHeight: number;
     readonly minHeight: number;
@@ -54,7 +54,7 @@ export class BlockCache<TBlock extends IBlockStub> implements ReadOnlyBlockCache
     // As the BlockCache has an on-disk store, a lock is used to serialize parallel write accesses
     private lock = new Lock();
 
-    public NewBlock = new BlockEvent<TBlock>();
+    public newBlock = new BlockEvent<TBlock>();
 
     /** True before the first block ever is added */
     public get isEmpty() {
@@ -120,7 +120,7 @@ export class BlockCache<TBlock extends IBlockStub> implements ReadOnlyBlockCache
             await this.blockStore.attached.set(height, block.hash, true);
 
             // A detached block became attached, thus we need to emit the new block event
-            await this.NewBlock.emit(block);
+            await this.newBlock.emit(block);
         }
 
         if (blocksToAdd.length > 0) {
@@ -179,7 +179,7 @@ export class BlockCache<TBlock extends IBlockStub> implements ReadOnlyBlockCache
                 await this.blockStore.block.set(block.number, block.hash, block);
                 await this.blockStore.attached.set(block.number, block.hash, true);
 
-                await this.NewBlock.emit(block);
+                await this.newBlock.emit(block);
 
                 // If the maximum block height increased, we might have to prune some old info
                 await this.updateMaxHeightAndPrune(block.number);

--- a/src/blockMonitor/blockProcessor.ts
+++ b/src/blockMonitor/blockProcessor.ts
@@ -128,7 +128,7 @@ export class BlockProcessor<TBlock extends IBlockStub> extends StartStopService 
 
     private mBlockCache: BlockCache<TBlock>;
 
-    public NewHead = new BlockEvent<TBlock>();
+    public newHead = new BlockEvent<TBlock>();
 
     // Returned in the constructor by blockProvider: obtains the block remotely (or throws an exception on failure)
     private getBlockRemote: (blockNumberOrHash: string | number) => Promise<TBlock>;
@@ -171,7 +171,7 @@ export class BlockProcessor<TBlock extends IBlockStub> extends StartStopService 
             this.mBlockCache.setHead(headBlock.hash);
 
             // only emit new head events after it is started
-            if (this.started) this.NewHead.emit(headBlock);
+            if (this.started) this.newHead.emit(headBlock);
 
             await this.store.setLatestHeadNumber(headBlock.number);
         } catch (doh) {

--- a/src/blockMonitor/blockProcessor.ts
+++ b/src/blockMonitor/blockProcessor.ts
@@ -7,6 +7,7 @@ import { BlockFetchingError, ApplicationError } from "../dataEntities/errors";
 import { LevelUp } from "levelup";
 import EncodingDown from "encoding-down";
 import { createNamedLogger, Logger } from "../logger";
+import { BlockEvent } from "../utils/event";
 const sub = require("subleveldown");
 
 type BlockFactory<TBlock> = (provider: ethers.providers.Provider) => (blockNumberOrHash: number | string) => Promise<TBlock>;
@@ -127,7 +128,7 @@ export class BlockProcessor<TBlock extends IBlockStub> extends StartStopService 
 
     private mBlockCache: BlockCache<TBlock>;
 
-    private newHeadListeners: NewHeadListener<TBlock>[] = [];
+    public NewHead = new BlockEvent<TBlock>();
 
     // Returned in the constructor by blockProvider: obtains the block remotely (or throws an exception on failure)
     private getBlockRemote: (blockNumberOrHash: string | number) => Promise<TBlock>;
@@ -164,34 +165,13 @@ export class BlockProcessor<TBlock extends IBlockStub> extends StartStopService 
         this.provider.removeListener("block", this.processBlockNumber);
     }
 
-    /**
-     * Adds a new listener for new head events.
-     * @param listener the listener for new head event; it will be passed the emitted `TBlock`.
-     */
-    public addNewHeadListener(listener: NewHeadListener<TBlock>) {
-        this.newHeadListeners.push(listener);
-    }
-
-    /**
-     * Removes `listener` from the list of listeners for new head events.
-     */
-    public removeNewHeadListener(listener: NewHeadListener<TBlock>) {
-        const idx = this.newHeadListeners.findIndex(l => l === listener);
-        if (idx === -1) throw new ApplicationError("No such listener exists.");
-
-        this.newHeadListeners.splice(idx, 1);
-    }
-
     // emits the appropriate events and updates the new head block in the store
     private async processNewHead(headBlock: Readonly<TBlock>) {
         try {
             this.mBlockCache.setHead(headBlock.hash);
 
             // only emit new head events after it is started
-            if (this.started) {
-                // Emit the new head
-                await Promise.all(this.newHeadListeners.map(listener => listener(headBlock)));
-            }
+            if (this.started) this.NewHead.emit(headBlock);
 
             await this.store.setLatestHeadNumber(headBlock.number);
         } catch (doh) {

--- a/src/blockMonitor/blockchainMachine.ts
+++ b/src/blockMonitor/blockchainMachine.ts
@@ -43,8 +43,8 @@ export class BlockchainMachine<TBlock extends IBlockStub> extends StartStopServi
         if (!this.actionStore.started) this.logger.error("The ActionStore should be started before the BlockchainMachine.");
         if (!this.blockItemStore.started) this.logger.error("The BlockItemStore should be started before the BlockchainMachine.");
 
-        this.blockProcessor.addNewHeadListener(this.processNewHead);
-        this.blockProcessor.blockCache.addNewBlockListener(this.processNewBlock);
+        this.blockProcessor.NewHead.addListener(this.processNewHead);
+        this.blockProcessor.blockCache.NewBlock.addListener(this.processNewBlock);
 
         // For each component, load and start any action that was stored in the ActionStore
         for (const component of this.components) {
@@ -54,8 +54,8 @@ export class BlockchainMachine<TBlock extends IBlockStub> extends StartStopServi
     }
 
     protected async stopInternal(): Promise<void> {
-        this.blockProcessor.removeNewHeadListener(this.processNewHead);
-        this.blockProcessor.blockCache.removeNewBlockListener(this.processNewBlock);
+        this.blockProcessor.NewHead.removeListener(this.processNewHead);
+        this.blockProcessor.blockCache.NewBlock.removeListener(this.processNewBlock);
     }
 
     constructor(private blockProcessor: BlockProcessor<TBlock>, private actionStore: ActionStore, private blockItemStore: BlockItemStore<TBlock>) {

--- a/src/blockMonitor/blockchainMachine.ts
+++ b/src/blockMonitor/blockchainMachine.ts
@@ -43,8 +43,8 @@ export class BlockchainMachine<TBlock extends IBlockStub> extends StartStopServi
         if (!this.actionStore.started) this.logger.error("The ActionStore should be started before the BlockchainMachine.");
         if (!this.blockItemStore.started) this.logger.error("The BlockItemStore should be started before the BlockchainMachine.");
 
-        this.blockProcessor.NewHead.addListener(this.processNewHead);
-        this.blockProcessor.blockCache.NewBlock.addListener(this.processNewBlock);
+        this.blockProcessor.newHead.addListener(this.processNewHead);
+        this.blockProcessor.blockCache.newBlock.addListener(this.processNewBlock);
 
         // For each component, load and start any action that was stored in the ActionStore
         for (const component of this.components) {
@@ -54,8 +54,8 @@ export class BlockchainMachine<TBlock extends IBlockStub> extends StartStopServi
     }
 
     protected async stopInternal(): Promise<void> {
-        this.blockProcessor.NewHead.removeListener(this.processNewHead);
-        this.blockProcessor.blockCache.NewBlock.removeListener(this.processNewBlock);
+        this.blockProcessor.newHead.removeListener(this.processNewHead);
+        this.blockProcessor.blockCache.newBlock.removeListener(this.processNewBlock);
     }
 
     constructor(private blockProcessor: BlockProcessor<TBlock>, private actionStore: ActionStore, private blockItemStore: BlockItemStore<TBlock>) {

--- a/src/utils/event.ts
+++ b/src/utils/event.ts
@@ -1,0 +1,26 @@
+import { IBlockStub, ApplicationError } from "../dataEntities";
+
+export abstract class Event<T extends Function> {
+    protected listeners: T[] = [];
+    addListener(listener: T) {
+        this.listeners.push(listener);
+    }
+    removeListener(listener: T) {
+        const idx = this.listeners.findIndex(l => l === listener);
+        if (idx === -1) throw new ApplicationError("No such listener exists.");
+
+        this.listeners.splice(idx, 1);
+    }
+}
+
+// A listener that receives a `TBlock` parameter
+type BlockListener<TBlock extends IBlockStub> = (block: TBlock) => Promise<void>;
+
+export class BlockEvent<TBlock extends IBlockStub> extends Event<BlockListener<TBlock>> {
+    protected listeners: BlockListener<TBlock>[] = [];
+    async emit(block: TBlock) {
+        for (const listener of this.listeners) {
+            await listener(block);
+        }
+    }
+}

--- a/src/utils/event.ts
+++ b/src/utils/event.ts
@@ -1,11 +1,25 @@
 import { IBlockStub, ApplicationError } from "../dataEntities";
 
-export abstract class Event<T extends Function> {
-    protected listeners: T[] = [];
-    addListener(listener: T) {
+/**
+ * This is a generic class to use as base for concrete classes to manage events and event listeners.
+ * The type parmeter TListener is the type of the event listeners, which should be a function returning a Promise.
+ * Concrete subclasses must implement an `emit` method method to actually emits the event and calls all the listeners,
+ * awaiting each one of them.
+ */
+export abstract class Event<TListener extends Function> {
+    protected listeners: TListener[] = [];
+
+    /**
+     * Adds `listener` to the list of listeners of the event.
+     */
+    public addListener(listener: TListener) {
         this.listeners.push(listener);
     }
-    removeListener(listener: T) {
+    /**
+     * Remove `listener` from the list of listeners of this event.
+     * @throws ApplicationError if `listener` is not among the listeners (either was not added, or was already removed).
+     */
+    public removeListener(listener: TListener) {
         const idx = this.listeners.findIndex(l => l === listener);
         if (idx === -1) throw new ApplicationError("No such listener exists.");
 
@@ -16,9 +30,12 @@ export abstract class Event<T extends Function> {
 // A listener that receives a `TBlock` parameter
 type BlockListener<TBlock extends IBlockStub> = (block: TBlock) => Promise<void>;
 
+/**
+ * An `Event` that emits a block of type `TBlock`.
+ */
 export class BlockEvent<TBlock extends IBlockStub> extends Event<BlockListener<TBlock>> {
     protected listeners: BlockListener<TBlock>[] = [];
-    async emit(block: TBlock) {
+    public async emit(block: TBlock) {
         for (const listener of this.listeners) {
             await listener(block);
         }

--- a/src/utils/event.ts
+++ b/src/utils/event.ts
@@ -6,7 +6,7 @@ import { IBlockStub, ApplicationError } from "../dataEntities";
  * Concrete subclasses must implement an `emit` method method to actually emits the event and calls all the listeners,
  * awaiting each one of them.
  */
-export abstract class Event<TListener extends Function> {
+export abstract class Event<TListener extends (...args: any[]) => Promise<void>> {
     protected listeners: TListener[] = [];
 
     /**

--- a/test/src/blockMonitor/blockCache.test.ts
+++ b/test/src/blockMonitor/blockCache.test.ts
@@ -93,7 +93,7 @@ describe("BlockCache", () => {
         const blocks = generateBlocks(10, 5, "main");
 
         const newBlockSpy = new NewBlockSpy();
-        bc.NewBlock.addListener(newBlockSpy.newBlockListener);
+        bc.newBlock.addListener(newBlockSpy.newBlockListener);
 
         await bc.addBlock(blocks[0]);
 
@@ -107,7 +107,7 @@ describe("BlockCache", () => {
         await bc.addBlock(blocks[0]);
 
         const newBlockSpy = new NewBlockSpy();
-        bc.NewBlock.addListener(newBlockSpy.newBlockListener);
+        bc.newBlock.addListener(newBlockSpy.newBlockListener);
 
         await bc.addBlock(blocks[2]); //unattached block
 
@@ -120,7 +120,7 @@ describe("BlockCache", () => {
         await bc.addBlock(blocks[0]);
 
         const newBlockSpy = new NewBlockSpy();
-        bc.NewBlock.addListener(newBlockSpy.newBlockListener);
+        bc.newBlock.addListener(newBlockSpy.newBlockListener);
 
         await bc.addBlock(blocks[2]); //unattached block
         await bc.addBlock(blocks[1]); //now both blocks become attached

--- a/test/src/blockMonitor/blockCache.test.ts
+++ b/test/src/blockMonitor/blockCache.test.ts
@@ -93,7 +93,7 @@ describe("BlockCache", () => {
         const blocks = generateBlocks(10, 5, "main");
 
         const newBlockSpy = new NewBlockSpy();
-        bc.addNewBlockListener(newBlockSpy.newBlockListener);
+        bc.NewBlock.addListener(newBlockSpy.newBlockListener);
 
         await bc.addBlock(blocks[0]);
 
@@ -107,7 +107,7 @@ describe("BlockCache", () => {
         await bc.addBlock(blocks[0]);
 
         const newBlockSpy = new NewBlockSpy();
-        bc.addNewBlockListener(newBlockSpy.newBlockListener);
+        bc.NewBlock.addListener(newBlockSpy.newBlockListener);
 
         await bc.addBlock(blocks[2]); //unattached block
 
@@ -120,7 +120,7 @@ describe("BlockCache", () => {
         await bc.addBlock(blocks[0]);
 
         const newBlockSpy = new NewBlockSpy();
-        bc.addNewBlockListener(newBlockSpy.newBlockListener);
+        bc.NewBlock.addListener(newBlockSpy.newBlockListener);
 
         await bc.addBlock(blocks[2]); //unattached block
         await bc.addBlock(blocks[1]); //now both blocks become attached

--- a/test/src/blockMonitor/blockProcessor.test.ts
+++ b/test/src/blockMonitor/blockProcessor.test.ts
@@ -101,11 +101,11 @@ describe("BlockProcessor", () => {
                     } else {
                         resolve({ number: block.number, hash: block.hash });
                     }
-                    bp.blockCache.removeNewBlockListener(newBlockHandler);
+                    bp.blockCache.NewBlock.removeListener(newBlockHandler);
                 }
             };
 
-            bp.blockCache.addNewBlockListener(newBlockHandler);
+            bp.blockCache.NewBlock.addListener(newBlockHandler);
         });
     };
 
@@ -198,7 +198,7 @@ describe("BlockProcessor", () => {
         let newHeadCalled = false;
 
         const newHeadPromise = new Promise(resolve => {
-            blockProcessor.addNewHeadListener(async (head: IBlockStub) => {
+            blockProcessor.NewHead.addListener(async (head: IBlockStub) => {
                 newHeadCalled = true;
                 if (!blockCache.hasBlock("a5")) resolve(new Error(`The BlockCache did not have block a5 when its new head event was emitted`));
 
@@ -213,9 +213,9 @@ describe("BlockProcessor", () => {
                 // New head should be the last emitted event
                 newHeadCalledBeforeNewBlock = true;
             }
-            blockCache.removeNewBlockListener(newBlockListener);
+            blockCache.NewBlock.removeListener(newBlockListener);
         };
-        blockCache.addNewBlockListener(newBlockListener);
+        blockCache.NewBlock.addListener(newBlockListener);
 
         emitBlockHash("a5");
 

--- a/test/src/blockMonitor/blockProcessor.test.ts
+++ b/test/src/blockMonitor/blockProcessor.test.ts
@@ -101,11 +101,11 @@ describe("BlockProcessor", () => {
                     } else {
                         resolve({ number: block.number, hash: block.hash });
                     }
-                    bp.blockCache.NewBlock.removeListener(newBlockHandler);
+                    bp.blockCache.newBlock.removeListener(newBlockHandler);
                 }
             };
 
-            bp.blockCache.NewBlock.addListener(newBlockHandler);
+            bp.blockCache.newBlock.addListener(newBlockHandler);
         });
     };
 
@@ -198,7 +198,7 @@ describe("BlockProcessor", () => {
         let newHeadCalled = false;
 
         const newHeadPromise = new Promise(resolve => {
-            blockProcessor.NewHead.addListener(async (head: IBlockStub) => {
+            blockProcessor.newHead.addListener(async (head: IBlockStub) => {
                 newHeadCalled = true;
                 if (!blockCache.hasBlock("a5")) resolve(new Error(`The BlockCache did not have block a5 when its new head event was emitted`));
 
@@ -213,9 +213,9 @@ describe("BlockProcessor", () => {
                 // New head should be the last emitted event
                 newHeadCalledBeforeNewBlock = true;
             }
-            blockCache.NewBlock.removeListener(newBlockListener);
+            blockCache.newBlock.removeListener(newBlockListener);
         };
-        blockCache.NewBlock.addListener(newBlockListener);
+        blockCache.newBlock.addListener(newBlockListener);
 
         emitBlockHash("a5");
 

--- a/test/src/blockMonitor/blockchainMachine.test.ts
+++ b/test/src/blockMonitor/blockchainMachine.test.ts
@@ -122,7 +122,7 @@ describe("BlockchainMachine", () => {
         // Since we only need to process events, we mock the BlockProcessor with an EventEmitter
         const bp: any = new MockBlockProcessor();
         bp.blockCache = blockCache;
-        blockProcessor = bp as (BlockProcessor<IBlockStub>);
+        blockProcessor = bp as BlockProcessor<IBlockStub>;
 
         actionStore = new ActionStore(db);
         await actionStore.start();

--- a/test/src/blockMonitor/blockchainMachine.test.ts
+++ b/test/src/blockMonitor/blockchainMachine.test.ts
@@ -86,12 +86,8 @@ class ExampleComponentWithSlowAction extends ExampleComponent {
     }
 }
 
-interface CanEmitAsNewHead {
-    emitAsNewHead(head: IBlockStub): Promise<void>;
-}
-
 class MockBlockProcessor {
-    public NewHead = new BlockEvent<IBlockStub>();
+    public newHead = new BlockEvent<IBlockStub>();
 }
 
 describe("BlockchainMachine", () => {
@@ -106,7 +102,7 @@ describe("BlockchainMachine", () => {
     // Utility function to add a block to the block cache and also emit it as new head in the blockProcessor.
     const addAndEmitBlock = async (block: IBlockStub) => {
         await blockCache.addBlock(block);
-        await blockProcessor.NewHead.emit(block);
+        await blockProcessor.newHead.emit(block);
     };
 
     beforeEach(async () => {

--- a/test/src/utils/event.test.ts
+++ b/test/src/utils/event.test.ts
@@ -1,0 +1,66 @@
+import "mocha";
+import { expect } from "chai";
+import fnIt from "../../utils/fnIt";
+import { Event, BlockEvent } from "../../../src/utils/event";
+import { IBlockStub, ApplicationError } from "../../../src/dataEntities";
+
+describe("Event", async () => {
+    const block: IBlockStub = {
+        number: 42,
+        hash: "0x4242",
+        parentHash: "0x1111"
+    };
+
+    fnIt<Event<any>>(e => e.addListener, "adds a listener and receives the event with the correct parameter", async () => {
+        const e = new BlockEvent<IBlockStub>();
+        let calledWith: any = null;
+        e.addListener(async (b: IBlockStub) => {
+            calledWith = b;
+        });
+
+        await e.emit(block);
+        expect(calledWith).to.deep.equal(block);
+    });
+
+    it("can add and remove a listener", async () => {
+        const e = new BlockEvent<IBlockStub>();
+        let calledWith: any = null;
+        const listener = async (b: IBlockStub) => {
+            calledWith = b;
+        };
+
+        e.addListener(listener);
+        e.removeListener(listener);
+
+        await e.emit(block);
+        expect(calledWith).to.be.null;
+    });
+
+    it("can add multiple listeners", async () => {
+        const e = new BlockEvent<IBlockStub>();
+        let calledWith1: any = null;
+        const listener1 = async (b: IBlockStub) => {
+            calledWith1 = b;
+        };
+        let calledWith2: any = null;
+        const listener2 = async (b: IBlockStub) => {
+            calledWith2 = b;
+        };
+
+        e.addListener(listener1);
+        e.addListener(listener2);
+
+        await e.emit(block);
+        expect(calledWith1).to.deep.equal(block);
+        expect(calledWith2).to.deep.equal(block);
+    });
+
+    fnIt<Event<any>>(e => e.removeListener, "throws ApplicationError if the listener does not exist", async () => {
+        const e = new BlockEvent<IBlockStub>();
+        const listener = async (b: IBlockStub) => {};
+        const otherListener = async (b: IBlockStub) => {};
+
+        e.addListener(listener);
+        expect(() => e.removeListener(otherListener)).to.throw(ApplicationError);
+    });
+});

--- a/test/src/utils/event.test.ts
+++ b/test/src/utils/event.test.ts
@@ -61,6 +61,9 @@ describe("Event", async () => {
         const otherListener = async (b: IBlockStub) => {};
 
         e.addListener(listener);
-        expect(() => e.removeListener(otherListener)).to.throw(ApplicationError);
+        expect(() => e.removeListener(otherListener), "throws for a listener that was never added").to.throw(ApplicationError);
+
+        e.removeListener(listener);
+        expect(() => e.removeListener(listener), "throws for a listener that was already removed").to.throw(ApplicationError);
     });
 });


### PR DESCRIPTION
This PR adds a base class Event and a derived concrete class BlockEvent to manage events and event listeners in a type-safe way. This removes some code duplication in the BlockProcessor and the BlockCache.

The base class contains the logic of adding and removing listeners, while concrede implementations implement the `emit` method that allows to call all the listeners for the event. All the listeners are emitted in sequence, and awaited for; thus, when the `emit` method resolves, the caller is guaranteed that all the listeners have been called and returned.

The concrete BlockEvent class implements an event that accepts a single `block` argument.