### PR TITLE
Batch updates to the BlockItemStore

### DIFF
--- a/src/blockMonitor/actionStore.ts
+++ b/src/blockMonitor/actionStore.ts
@@ -57,8 +57,8 @@ export class ActionStore extends StartStopService {
         else this.actions.set(componentName, new Set(actionsWithId));
 
         let batch = this.subDb.batch();
-        actionsWithId.forEach(actionWithId => {
-            batch = batch.put(componentName + ":" + actionWithId.id, actionWithId.action);
+        actionsWithId.forEach(({ id, action }) => {
+            batch = batch.put(componentName + ":" + id, action);
         });
         await batch.write();
         return actionsWithId;

--- a/src/blockMonitor/blockCache.ts
+++ b/src/blockMonitor/blockCache.ts
@@ -117,7 +117,7 @@ export class BlockCache<TBlock extends IBlockStub> implements ReadOnlyBlockCache
 
         for (const { block } of blocksToAdd) {
             // Update the block in the db (as it is now attached)
-            await this.blockStore.attached.set(height, block.hash, true);
+            this.blockStore.attached.set(height, block.hash, true);
 
             // A detached block became attached, thus we need to emit the new block event
             await this.newBlock.emit(block);
@@ -175,26 +175,28 @@ export class BlockCache<TBlock extends IBlockStub> implements ReadOnlyBlockCache
             }
 
             if (this.canAttachBlock(block)) {
-                // This should happen atomically once the BlockStoreItem is refactored to allow batching
-                await this.blockStore.block.set(block.number, block.hash, block);
-                await this.blockStore.attached.set(block.number, block.hash, true);
+                await this.blockStore.withBatch(async () => {
+                    await this.blockStore.block.set(block.number, block.hash, block);
+                    await this.blockStore.attached.set(block.number, block.hash, true);
 
-                await this.newBlock.emit(block);
+                    await this.newBlock.emit(block);
 
-                // If the maximum block height increased, we might have to prune some old info
-                await this.updateMaxHeightAndPrune(block.number);
+                    // If the maximum block height increased, we might have to prune some old info
+                    await this.updateMaxHeightAndPrune(block.number);
 
-                // Since we added a new block, some detached blocks might become attached
-                await this.processDetached(block.number + 1);
+                    // Since we added a new block, some detached blocks might become attached
+                    await this.processDetached(block.number + 1);
 
-                // If the minHeight increased, this could also make some detached blocks ready to be attached
-                // This makes sure that they are attached if necessary
-                await this.processDetachedBlocksAtMinHeight();
+                    // If the minHeight increased, this could also make some detached blocks ready to be attached
+                    // This makes sure that they are attached if necessary
+                    await this.processDetachedBlocksAtMinHeight();
+                })
                 return BlockAddResult.Added;
             } else {
-                // This should happen atomically once the BlockStoreItem is refactored to allow batching
-                await this.blockStore.block.set(block.number, block.hash, block);
-                await this.blockStore.attached.set(block.number, block.hash, false);
+                await this.blockStore.withBatch(async () => {
+                    await this.blockStore.block.set(block.number, block.hash, block);
+                    await this.blockStore.attached.set(block.number, block.hash, false);
+                });
                 return BlockAddResult.AddedDetached;
             }
         } finally {

--- a/src/blockMonitor/blockProcessor.ts
+++ b/src/blockMonitor/blockProcessor.ts
@@ -173,7 +173,7 @@ export class BlockProcessor<TBlock extends IBlockStub> extends StartStopService 
                 this.mBlockCache.setHead(headBlock.hash);
 
                 // only emit new head events after it is started
-                if (this.started) this.newHead.emit(headBlock);
+                if (this.started) await this.newHead.emit(headBlock);
 
                 await this.store.setLatestHeadNumber(headBlock.number);
             });

--- a/src/blockMonitor/blockProcessor.ts
+++ b/src/blockMonitor/blockProcessor.ts
@@ -174,9 +174,9 @@ export class BlockProcessor<TBlock extends IBlockStub> extends StartStopService 
 
                 // only emit new head events after it is started
                 if (this.started) await this.newHead.emit(headBlock);
-
-                await this.store.setLatestHeadNumber(headBlock.number);
             });
+
+            await this.store.setLatestHeadNumber(headBlock.number);
         } catch (doh) {
             this.logger.error(doh);
         }

--- a/src/blockMonitor/blockProcessor.ts
+++ b/src/blockMonitor/blockProcessor.ts
@@ -168,18 +168,18 @@ export class BlockProcessor<TBlock extends IBlockStub> extends StartStopService 
 
     // emits the appropriate events and updates the new head block in the store
     private async processNewHead(headBlock: Readonly<TBlock>) {
-        await this.blockItemStore.withBatch(async () => {
-            try {
+        try {
+            await this.blockItemStore.withBatch(async () => {
                 this.mBlockCache.setHead(headBlock.hash);
 
                 // only emit new head events after it is started
                 if (this.started) this.newHead.emit(headBlock);
 
                 await this.store.setLatestHeadNumber(headBlock.number);
-            } catch (doh) {
-                this.logger.error(doh);
-            }
-        });
+            });
+        } catch (doh) {
+            this.logger.error(doh);
+        }
     }
 
     // Checks if a block is already in the block cache; if not, requests it remotely.

--- a/src/blockMonitor/blockProcessor.ts
+++ b/src/blockMonitor/blockProcessor.ts
@@ -214,7 +214,11 @@ export class BlockProcessor<TBlock extends IBlockStub> extends StartStopService 
                 // starting from observedBlock, add to the cache and download the parent, until the return value signals that block is attached
                 let curBlock = observedBlock;
                 while (true) {
-                    const addResult = await this.mBlockCache.addBlock(curBlock)
+                    let addResult: BlockAddResult | null = null;
+                    await this.blockItemStore.withBatch(async () => {
+                        addResult = await this.mBlockCache.addBlock(curBlock);
+                    });
+
                     if (addResult !== BlockAddResult.AddedDetached && addResult !== BlockAddResult.NotAddedAlreadyExistedDetached)
                         break;
 

--- a/src/blockMonitor/blockchainMachine.ts
+++ b/src/blockMonitor/blockchainMachine.ts
@@ -133,9 +133,6 @@ export class BlockchainMachine<TBlock extends IBlockStub> extends StartStopServi
 
                 const prevEmittedState: AnchorState | null = this.blockItemStore.prevEmittedAnchorState.get(component.name, head.hash);
 
-                // this is now the latest anchor stated for an emitted head block; update the store accordingly
-                this.blockItemStore.prevEmittedAnchorState.set(component.name, head.number, head.hash, state);
-
                 if (prevEmittedState) {
                     // save actions in the store
                     const newActions = component.detectChanges(prevEmittedState, state);
@@ -144,6 +141,9 @@ export class BlockchainMachine<TBlock extends IBlockStub> extends StartStopServi
                         this.runActionsForComponent(component, actionAndIds);
                     }
                 }
+
+                // this is now the latest anchor stated for an emitted head block; update the store accordingly
+                this.blockItemStore.prevEmittedAnchorState.set(component.name, head.number, head.hash, state);
             }
         } finally {
             this.lock.release();

--- a/src/blockMonitor/blockchainMachine.ts
+++ b/src/blockMonitor/blockchainMachine.ts
@@ -142,7 +142,6 @@ export class BlockchainMachine<TBlock extends IBlockStub> extends StartStopServi
                     if (newActions.length > 0) {
                         const actionAndIds = await this.actionStore.storeActions(component.name, newActions);
                         this.runActionsForComponent(component, actionAndIds);
-
                     }
                 }
             }

--- a/src/blockMonitor/blockchainMachine.ts
+++ b/src/blockMonitor/blockchainMachine.ts
@@ -81,35 +81,33 @@ export class BlockchainMachine<TBlock extends IBlockStub> extends StartStopServi
             await this.lock.acquire();
 
             // Every time a new block is received we calculate the anchor state for that block and store it
-            await this.blockItemStore.withBatch(async () => {
-                for (const component of this.components) {
-                    // If the parent is available and its anchor state is known, the state can be computed with the reducer.
-                    // If the parent is available but its anchor state is not known, first compute its parent's initial state, then apply the reducer.
-                    // Finally, if the parent is not available at all in the block cache, compute the initial state based on the current block.
+            for (const component of this.components) {
+                // If the parent is available and its anchor state is known, the state can be computed with the reducer.
+                // If the parent is available but its anchor state is not known, first compute its parent's initial state, then apply the reducer.
+                // Finally, if the parent is not available at all in the block cache, compute the initial state based on the current block.
 
-                    let newState: AnchorState;
-                    let prevHeadAnchorState: AnchorState | null = null;
-                    if (this.blockProcessor.blockCache.hasBlock(block.parentHash)) {
-                        const parentBlock = this.blockProcessor.blockCache.getBlock(block.parentHash);
+                let newState: AnchorState;
+                let prevHeadAnchorState: AnchorState | null = null;
+                if (this.blockProcessor.blockCache.hasBlock(block.parentHash)) {
+                    const parentBlock = this.blockProcessor.blockCache.getBlock(block.parentHash);
 
-                        prevHeadAnchorState = this.blockItemStore.prevEmittedAnchorState.get(component.name, parentBlock.hash);
+                    prevHeadAnchorState = this.blockItemStore.prevEmittedAnchorState.get(component.name, parentBlock.hash);
 
-                        const prevAnchorState =
-                            this.blockItemStore.anchorState.get<AnchorState>(component.name, parentBlock.hash) ||
-                            component.reducer.getInitialState(parentBlock); // prettier-ignore
+                    const prevAnchorState =
+                        this.blockItemStore.anchorState.get<AnchorState>(component.name, parentBlock.hash) ||
+                        component.reducer.getInitialState(parentBlock); // prettier-ignore
 
-                        newState = component.reducer.reduce(prevAnchorState, block);
-                    } else {
-                        newState = component.reducer.getInitialState(block);
-                    }
-
-                    this.blockItemStore.anchorState.set(component.name, block.number, block.hash, newState);
-                    if (prevHeadAnchorState) {
-                        // copy prevEmittedAnchorState from the previous block
-                        this.blockItemStore.prevEmittedAnchorState.set(component.name, block.number, block.hash, prevHeadAnchorState);
-                    }
+                    newState = component.reducer.reduce(prevAnchorState, block);
+                } else {
+                    newState = component.reducer.getInitialState(block);
                 }
-            });
+
+                this.blockItemStore.anchorState.set(component.name, block.number, block.hash, newState);
+                if (prevHeadAnchorState) {
+                    // copy prevEmittedAnchorState from the previous block
+                    this.blockItemStore.prevEmittedAnchorState.set(component.name, block.number, block.hash, prevHeadAnchorState);
+                }
+            }
         } finally {
             this.lock.release();
         }
@@ -123,33 +121,31 @@ export class BlockchainMachine<TBlock extends IBlockStub> extends StartStopServi
             // between the old head and the head. We compute this now for each of the
             // components
 
-            await this.blockItemStore.withBatch(async () => {
-                for (const component of this.components) {
-                    const state: AnchorState = this.blockItemStore.anchorState.get(component.name, head.hash);
-                    if (state == undefined) {
-                        // Since processNewBlock is always called before processNewHead, this should never happen
-                        this.logger.error(
-                            `State for component ${component.constructor.name} for block ${head.hash} (number ${head.number}) was not set, but it should have been.`
-                        );
-                        return;
-                    }
+            for (const component of this.components) {
+                const state: AnchorState = this.blockItemStore.anchorState.get(component.name, head.hash);
+                if (state == undefined) {
+                    // Since processNewBlock is always called before processNewHead, this should never happen
+                    this.logger.error(
+                        `State for component ${component.constructor.name} for block ${head.hash} (number ${head.number}) was not set, but it should have been.`
+                    );
+                    return;
+                }
 
-                    const prevEmittedState: AnchorState | null = this.blockItemStore.prevEmittedAnchorState.get(component.name, head.hash);
+                const prevEmittedState: AnchorState | null = this.blockItemStore.prevEmittedAnchorState.get(component.name, head.hash);
 
-                    // this is now the latest anchor stated for an emitted head block; update the store accordingly
-                    this.blockItemStore.prevEmittedAnchorState.set(component.name, head.number, head.hash, state);
+                // this is now the latest anchor stated for an emitted head block; update the store accordingly
+                this.blockItemStore.prevEmittedAnchorState.set(component.name, head.number, head.hash, state);
 
-                    if (prevEmittedState) {
-                        // save actions in the store
-                        const newActions = component.detectChanges(prevEmittedState, state);
-                        if (newActions.length > 0) {
-                            const actionAndIds = await this.actionStore.storeActions(component.name, newActions);
-                            this.runActionsForComponent(component, actionAndIds);
+                if (prevEmittedState) {
+                    // save actions in the store
+                    const newActions = component.detectChanges(prevEmittedState, state);
+                    if (newActions.length > 0) {
+                        const actionAndIds = await this.actionStore.storeActions(component.name, newActions);
+                        this.runActionsForComponent(component, actionAndIds);
 
-                        }
                     }
                 }
-            });
+            }
         } finally {
             this.lock.release();
         }

--- a/src/service.ts
+++ b/src/service.ts
@@ -72,7 +72,7 @@ export class PisaService extends StartStopService {
         this.blockItemStore = new BlockItemStore<Block>(db);
         const blockCache = new BlockCache<Block>(cacheLimit, this.blockItemStore);
         const blockProcessorStore = new BlockProcessorStore(db);
-        this.blockProcessor = new BlockProcessor<Block>(provider, blockFactory, blockCache, blockProcessorStore);
+        this.blockProcessor = new BlockProcessor<Block>(provider, blockFactory, blockCache, this.blockItemStore, blockProcessorStore);
 
         // stores
         this.appointmentStore = new AppointmentStore(db);

--- a/test/src/blockMonitor/blockCache.test.ts
+++ b/test/src/blockMonitor/blockCache.test.ts
@@ -58,413 +58,486 @@ describe("BlockCache", () => {
     beforeEach(async () => {
         db = LevelUp(EncodingDown<string, any>(MemDown(), { valueEncoding: "json" }));
         blockStore = new BlockItemStore<IBlockStub>(db);
-        await blockStore.start();
     });
 
     afterEach(async () => await blockStore.stop());
 
     it("records a block that was just added", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        const blocks = generateBlocks(1, 0, "main");
+        await blockStore.withBatch( async () => {
+            const blocks = generateBlocks(1, 0, "main");
 
-        await bc.addBlock(blocks[0]);
+            await bc.addBlock(blocks[0]);
 
-        expect(blocks[0]).to.deep.include(bc.getBlock(blocks[0].hash));
+            expect(blocks[0]).to.deep.include(bc.getBlock(blocks[0].hash));
+        });
     });
 
     fnIt<BlockCache<any>>(b => b.addBlock, "adds blocks that are attached and returns Added", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        const blocks = generateBlocks(10, 5, "main");
-        expect(await bc.addBlock(blocks[0])).to.equal(BlockAddResult.Added);
-        expect(await bc.addBlock(blocks[1])).to.equal(BlockAddResult.Added);
-        expect(await bc.addBlock(blocks[2])).to.equal(BlockAddResult.Added);
+        await blockStore.withBatch( async () => {
+            const blocks = generateBlocks(10, 5, "main");
+            expect(await bc.addBlock(blocks[0])).to.equal(BlockAddResult.Added);
+            expect(await bc.addBlock(blocks[1])).to.equal(BlockAddResult.Added);
+            expect(await bc.addBlock(blocks[2])).to.equal(BlockAddResult.Added);
+        });
     });
 
     fnIt<BlockCache<any>>(b => b.addBlock, "adds unattached blocks and returns false", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        const blocks = generateBlocks(10, 5, "main");
-        await bc.addBlock(blocks[0]);
-        expect(await bc.addBlock(blocks[3])).to.equal(BlockAddResult.AddedDetached);
-        expect(await bc.addBlock(blocks[2])).to.equal(BlockAddResult.AddedDetached);
+        await blockStore.withBatch( async () => {
+            const blocks = generateBlocks(10, 5, "main");
+            await bc.addBlock(blocks[0]);
+            expect(await bc.addBlock(blocks[3])).to.equal(BlockAddResult.AddedDetached);
+            expect(await bc.addBlock(blocks[2])).to.equal(BlockAddResult.AddedDetached);
+        });
     });
 
     it("emits a new block event when a new block is added and attached", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        const blocks = generateBlocks(10, 5, "main");
+        await blockStore.withBatch( async () => {
+            const blocks = generateBlocks(10, 5, "main");
 
-        const newBlockSpy = new NewBlockSpy();
-        bc.newBlock.addListener(newBlockSpy.newBlockListener);
+            const newBlockSpy = new NewBlockSpy();
+            bc.newBlock.addListener(newBlockSpy.newBlockListener);
 
-        await bc.addBlock(blocks[0]);
+            await bc.addBlock(blocks[0]);
 
-        expect(newBlockSpy.callCounter).to.equal(1);
-        expect(newBlockSpy.lastCallBlock).to.equal(blocks[0]);
+            expect(newBlockSpy.callCounter).to.equal(1);
+            expect(newBlockSpy.lastCallBlock).to.equal(blocks[0]);
+        });
     });
 
     it("does not emit a new block event when a new block is added unattached", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        const blocks = generateBlocks(10, 5, "main");
-        await bc.addBlock(blocks[0]);
+        await blockStore.withBatch( async () => {
+            const blocks = generateBlocks(10, 5, "main");
+            await bc.addBlock(blocks[0]);
 
-        const newBlockSpy = new NewBlockSpy();
-        bc.newBlock.addListener(newBlockSpy.newBlockListener);
+            const newBlockSpy = new NewBlockSpy();
+            bc.newBlock.addListener(newBlockSpy.newBlockListener);
 
-        await bc.addBlock(blocks[2]); //unattached block
+            await bc.addBlock(blocks[2]); //unattached block
 
-        expect(newBlockSpy.callCounter).to.equal(0);
+            expect(newBlockSpy.callCounter).to.equal(0);
+        });
     });
 
     it("emits a new block event when an unattached block becomes attached", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        const blocks = generateBlocks(10, 5, "main");
-        await bc.addBlock(blocks[0]);
+        await blockStore.withBatch( async () => {
+            const blocks = generateBlocks(10, 5, "main");
+            await bc.addBlock(blocks[0]);
 
-        const newBlockSpy = new NewBlockSpy();
-        bc.newBlock.addListener(newBlockSpy.newBlockListener);
+            const newBlockSpy = new NewBlockSpy();
+            bc.newBlock.addListener(newBlockSpy.newBlockListener);
 
-        await bc.addBlock(blocks[2]); //unattached block
-        await bc.addBlock(blocks[1]); //now both blocks become attached
+            await bc.addBlock(blocks[2]); //unattached block
+            await bc.addBlock(blocks[1]); //now both blocks become attached
 
-        expect(newBlockSpy.callCounter).to.equal(2);
-        expect(newBlockSpy.lastCallBlock).to.deep.equal(blocks[2]);
+            expect(newBlockSpy.callCounter).to.equal(2);
+            expect(newBlockSpy.lastCallBlock).to.deep.equal(blocks[2]);
+        });
     });
 
     fnIt<BlockCache<any>>(b => b.hasBlock, "returns true for an existing attached block", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        const blocks = generateBlocks(10, 5, "main");
-        await bc.addBlock(blocks[0]);
-        await bc.addBlock(blocks[1]);
-        expect(bc.hasBlock(blocks[1].hash)).to.be.true;
+        await blockStore.withBatch( async () => {
+            const blocks = generateBlocks(10, 5, "main");
+            await bc.addBlock(blocks[0]);
+            await bc.addBlock(blocks[1]);
+            expect(bc.hasBlock(blocks[1].hash)).to.be.true;
+        });
     });
 
     fnIt<BlockCache<any>>(b => b.hasBlock, "returns false for a non-existing block", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        const blocks = generateBlocks(10, 5, "main");
-        await bc.addBlock(blocks[0]);
-        await bc.addBlock(blocks[1]);
-        expect(bc.hasBlock("someNonExistingHash")).to.be.false;
+        await blockStore.withBatch( async () => {
+            const blocks = generateBlocks(10, 5, "main");
+            await bc.addBlock(blocks[0]);
+            await bc.addBlock(blocks[1]);
+            expect(bc.hasBlock("someNonExistingHash")).to.be.false;
+        });
     });
 
     fnIt<BlockCache<any>>(b => b.hasBlock, "returns false for an unattached block if allowPending=false", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        const blocks = generateBlocks(10, 5, "main");
-        await bc.addBlock(blocks[0]);
-        await bc.addBlock(blocks[1]);
-        await bc.addBlock(blocks[3]);
-        expect(bc.hasBlock(blocks[3].hash, false)).to.be.false;
+        await blockStore.withBatch( async () => {
+            const blocks = generateBlocks(10, 5, "main");
+            await bc.addBlock(blocks[0]);
+            await bc.addBlock(blocks[1]);
+            await bc.addBlock(blocks[3]);
+            expect(bc.hasBlock(blocks[3].hash, false)).to.be.false;
+        });
     });
 
     fnIt<BlockCache<any>>(b => b.hasBlock, "returns true for an unattached block if allowPending=true", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        const blocks = generateBlocks(10, 5, "main");
-        await bc.addBlock(blocks[0]);
-        await bc.addBlock(blocks[1]);
-        await bc.addBlock(blocks[3]);
-        expect(bc.hasBlock(blocks[3].hash, true)).to.be.true;
+        await blockStore.withBatch( async () => {
+            const blocks = generateBlocks(10, 5, "main");
+            await bc.addBlock(blocks[0]);
+            await bc.addBlock(blocks[1]);
+            await bc.addBlock(blocks[3]);
+            expect(bc.hasBlock(blocks[3].hash, true)).to.be.true;
+        });
     });
 
     fnIt<BlockCache<any>>(b => b.addBlock, "makes sure that a previously unattached block becomes attached if appropriate", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        const blocks = generateBlocks(10, 5, "main");
-        await bc.addBlock(blocks[0]);
-        await bc.addBlock(blocks[3]);
-        await bc.addBlock(blocks[2]);
+        await blockStore.withBatch( async () => {
+            const blocks = generateBlocks(10, 5, "main");
+            await bc.addBlock(blocks[0]);
+            await bc.addBlock(blocks[3]);
+            await bc.addBlock(blocks[2]);
 
-        expect(await bc.addBlock(blocks[1])).to.equal(BlockAddResult.Added);
+            expect(await bc.addBlock(blocks[1])).to.equal(BlockAddResult.Added);
 
-        expect(bc.maxHeight).to.equal(blocks[3].number);
-        expect(bc.hasBlock(blocks[3].hash)).to.be.true;
+            expect(bc.maxHeight).to.equal(blocks[3].number);
+            expect(bc.hasBlock(blocks[3].hash)).to.be.true;
+        });
     });
 
     it("maxHeight does not change for unattached blocks", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        const blocks = generateBlocks(10, 5, "main");
-        await bc.addBlock(blocks[0]);
-        await bc.addBlock(blocks[3]);
-        expect(bc.maxHeight).to.equal(blocks[0].number);
+        await blockStore.withBatch( async () => {
+            const blocks = generateBlocks(10, 5, "main");
+            await bc.addBlock(blocks[0]);
+            await bc.addBlock(blocks[3]);
+            expect(bc.maxHeight).to.equal(blocks[0].number);
+        });
     });
 
     fnIt<BlockCache<any>>(b => b.getBlock, "returns an attached block", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        const blocks = generateBlocks(10, 5, "main");
-        await bc.addBlock(blocks[0]);
-        await bc.addBlock(blocks[1]);
-        await bc.addBlock(blocks[3]);
-        expect(bc.getBlock(blocks[1].hash)).to.deep.equal(blocks[1]);
+        await blockStore.withBatch( async () => {
+            const blocks = generateBlocks(10, 5, "main");
+            await bc.addBlock(blocks[0]);
+            await bc.addBlock(blocks[1]);
+            await bc.addBlock(blocks[3]);
+            expect(bc.getBlock(blocks[1].hash)).to.deep.equal(blocks[1]);
+        });
     });
 
     fnIt<BlockCache<any>>(b => b.getBlock, "returns an unattached block", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        const blocks = generateBlocks(10, 5, "main");
-        await bc.addBlock(blocks[0]);
-        await bc.addBlock(blocks[1]);
-        await bc.addBlock(blocks[3]);
-        expect(bc.getBlock(blocks[3].hash)).to.deep.equal(blocks[3]);
+        await blockStore.withBatch( async () => {
+            const blocks = generateBlocks(10, 5, "main");
+            await bc.addBlock(blocks[0]);
+            await bc.addBlock(blocks[1]);
+            await bc.addBlock(blocks[3]);
+            expect(bc.getBlock(blocks[3].hash)).to.deep.equal(blocks[3]);
+        });
     });
 
     fnIt<BlockCache<any>>(b => b.getBlock, "throws ApplicationError for an unknown block", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        const blocks = generateBlocks(10, 5, "main");
-        await bc.addBlock(blocks[0]);
-        await bc.addBlock(blocks[1]);
-        await bc.addBlock(blocks[3]);
-        expect(() => bc.getBlock("someNonExistingHash")).to.throw(ApplicationError);
+        await blockStore.withBatch( async () => {
+            const blocks = generateBlocks(10, 5, "main");
+            await bc.addBlock(blocks[0]);
+            await bc.addBlock(blocks[1]);
+            await bc.addBlock(blocks[3]);
+            expect(() => bc.getBlock("someNonExistingHash")).to.throw(ApplicationError);
+        });
     });
 
     it("minHeight is equal to the initial block height if less then maxDepth blocks are added", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        const initialHeight = 3;
-        const blocks = generateBlocks(maxDepth - 1, initialHeight, "main");
+        await blockStore.withBatch( async () => {
+            const initialHeight = 3;
+            const blocks = generateBlocks(maxDepth - 1, initialHeight, "main");
 
-        for (const block of blocks) {
-            await bc.addBlock(block);
-        }
+            for (const block of blocks) {
+                await bc.addBlock(block);
+            }
 
-        expect(bc.minHeight).to.equal(initialHeight);
+            expect(bc.minHeight).to.equal(initialHeight);
+        });
     });
 
     it("minHeight is equal to the height of the highest added block minus maxDepth if more than maxDepth blocks are added", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        const initialHeight = 3;
-        const blocksAdded = 2 * maxDepth;
-        const lastBlockAdded = initialHeight + blocksAdded - 1;
-        const blocks = generateBlocks(blocksAdded, initialHeight, "main");
-        for (const block of blocks) {
-            await bc.addBlock(block);
-        }
-        expect(bc.minHeight).to.equal(lastBlockAdded - maxDepth);
+        await blockStore.withBatch( async () => {
+            const initialHeight = 3;
+            const blocksAdded = 2 * maxDepth;
+            const lastBlockAdded = initialHeight + blocksAdded - 1;
+            const blocks = generateBlocks(blocksAdded, initialHeight, "main");
+            for (const block of blocks) {
+                await bc.addBlock(block);
+            }
+            expect(bc.minHeight).to.equal(lastBlockAdded - maxDepth);
+        });
     });
 
     it("maxHeight is equal to the height of the highest added block", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        const initialHeight = 3;
-        const blocksAdded = 2 * maxDepth;
-        const lastBlockAdded = initialHeight + blocksAdded - 1;
+        await blockStore.withBatch( async () => {
+            const initialHeight = 3;
+            const blocksAdded = 2 * maxDepth;
+            const lastBlockAdded = initialHeight + blocksAdded - 1;
 
-        // Add some blocks
-        for (const block of generateBlocks(blocksAdded, initialHeight, "main")) {
-            await bc.addBlock(block);
-        }
-        // Add a shorter separate chain
-        for (const block of generateBlocks(blocksAdded - 1, initialHeight, "forkedchain")) {
-            await bc.addBlock(block);
-        }
+            // Add some blocks
+            for (const block of generateBlocks(blocksAdded, initialHeight, "main")) {
+                await bc.addBlock(block);
+            }
+            // Add a shorter separate chain
+            for (const block of generateBlocks(blocksAdded - 1, initialHeight, "forkedchain")) {
+                await bc.addBlock(block);
+            }
 
-        expect(bc.maxHeight).to.equal(lastBlockAdded);
+            expect(bc.maxHeight).to.equal(lastBlockAdded);
+        });
     });
 
     fnIt<BlockCache<any>>(b => b.canAttachBlock, "returns true for blocks whose height is equal to the initial height", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
+        await blockStore.withBatch( async () => {
 
-        const blocks = generateBlocks(10, 5, "main");
-        const otherBlocks = generateBlocks(10, 5, "other");
+            const blocks = generateBlocks(10, 5, "main");
+            const otherBlocks = generateBlocks(10, 5, "other");
 
-        await bc.addBlock(blocks[3]);
+            await bc.addBlock(blocks[3]);
 
-        expect(bc.canAttachBlock(blocks[3])).to.be.true;
-        expect(bc.canAttachBlock(otherBlocks[3])).to.be.true;
+            expect(bc.canAttachBlock(blocks[3])).to.be.true;
+            expect(bc.canAttachBlock(otherBlocks[3])).to.be.true;
+        });
     });
 
     fnIt<BlockCache<any>>(b => b.canAttachBlock, "returns false for blocks whose height is lower than the initial height", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
+        await blockStore.withBatch( async () => {
 
-        const blocks = generateBlocks(10, 5, "main");
-        const otherBlocks = generateBlocks(10, 5, "other");
+            const blocks = generateBlocks(10, 5, "main");
+            const otherBlocks = generateBlocks(10, 5, "other");
 
-        await bc.addBlock(blocks[3]);
+            await bc.addBlock(blocks[3]);
 
-        expect(bc.canAttachBlock(blocks[2])).to.be.false;
-        expect(bc.canAttachBlock(otherBlocks[2])).to.be.false;
+            expect(bc.canAttachBlock(blocks[2])).to.be.false;
+            expect(bc.canAttachBlock(otherBlocks[2])).to.be.false;
+        });
     });
 
     fnIt<BlockCache<any>>(b => b.canAttachBlock, "returns true for a block whose height is equal to the maximum depth", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        const initialHeight = 3;
-        const blocksAdded = maxDepth + 1;
-        const blocks = generateBlocks(blocksAdded, initialHeight, "main");
-        for (const block of blocks) {
-            await bc.addBlock(block);
-        }
-        const otherBlocks = generateBlocks(2, initialHeight - 1, "main");
+        await blockStore.withBatch( async () => {
+            const initialHeight = 3;
+            const blocksAdded = maxDepth + 1;
+            const blocks = generateBlocks(blocksAdded, initialHeight, "main");
+            for (const block of blocks) {
+                await bc.addBlock(block);
+            }
+            const otherBlocks = generateBlocks(2, initialHeight - 1, "main");
 
-        expect(bc.canAttachBlock(otherBlocks[1])).to.be.true;
+            expect(bc.canAttachBlock(otherBlocks[1])).to.be.true;
+        });
     });
 
     fnIt<BlockCache<any>>(b => b.canAttachBlock, "returns false for blocks whose height is lower than the maximum depth", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        const initialHeight = 3;
-        const blocksAdded = maxDepth + 1;
-        const blocks = generateBlocks(blocksAdded, initialHeight, "main");
-        for (const block of blocks) {
-            await bc.addBlock(block);
-        }
-        const otherBlocks = generateBlocks(2, initialHeight - 1, "main");
+        await blockStore.withBatch( async () => {
+            const initialHeight = 3;
+            const blocksAdded = maxDepth + 1;
+            const blocks = generateBlocks(blocksAdded, initialHeight, "main");
+            for (const block of blocks) {
+                await bc.addBlock(block);
+            }
+            const otherBlocks = generateBlocks(2, initialHeight - 1, "main");
 
-        expect(bc.canAttachBlock(otherBlocks[0])).to.be.false;
+            expect(bc.canAttachBlock(otherBlocks[0])).to.be.false;
+        });
     });
 
     fnIt<BlockCache<any>>(b => b.canAttachBlock, "returns true for a block whose parent is in the BlockCache", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        const blocks = generateBlocks(10, 7, "main");
+        await blockStore.withBatch( async () => {
+            const blocks = generateBlocks(10, 7, "main");
 
-        await bc.addBlock(blocks[5]);
+            await bc.addBlock(blocks[5]);
 
-        expect(bc.canAttachBlock(blocks[6])).to.be.true;
+            expect(bc.canAttachBlock(blocks[6])).to.be.true;
+        });
     });
 
     fnIt<BlockCache<any>>(b => b.canAttachBlock, "returns false for a block above minHeight whose parent is not in the BlockCache", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        const blocks = generateBlocks(10, 7, "main");
+        await blockStore.withBatch( async () => {
+            const blocks = generateBlocks(10, 7, "main");
 
-        await bc.addBlock(blocks[0]);
-        await bc.addBlock(blocks[1]);
-        await bc.addBlock(blocks[2]);
+            await bc.addBlock(blocks[0]);
+            await bc.addBlock(blocks[1]);
+            await bc.addBlock(blocks[2]);
 
-        expect(bc.canAttachBlock(blocks[4])).to.be.false;
+            expect(bc.canAttachBlock(blocks[4])).to.be.false;
+        });
     });
 
     it("records blocks until maximum depth", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        const blocks = generateBlocks(maxDepth, 0, "main");
-        for (const block of blocks) {
-            await bc.addBlock(block);
-        }
-        expect(blocks[0]).to.deep.include(bc.getBlock(blocks[0].hash));
+        await blockStore.withBatch( async () => {
+            const blocks = generateBlocks(maxDepth, 0, "main");
+            for (const block of blocks) {
+                await bc.addBlock(block);
+            }
+            expect(blocks[0]).to.deep.include(bc.getBlock(blocks[0].hash));
+        });
     });
 
     it("forgets blocks past the maximum depth", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        const blocks = generateBlocks(maxDepth + 2, 0, "main"); // head is depth 0, so first pruned is maxDepth + 2
-        for (const block of blocks) {
-            await bc.addBlock(block);
-        }
-        expect(() => bc.getBlock(blocks[0].hash)).to.throw(ApplicationError);
+        await blockStore.withBatch( async () => {
+            const blocks = generateBlocks(maxDepth + 2, 0, "main"); // head is depth 0, so first pruned is maxDepth + 2
+            for (const block of blocks) {
+                await bc.addBlock(block);
+            }
+            expect(() => bc.getBlock(blocks[0].hash)).to.throw(ApplicationError);
+        });
     });
 
     fnIt<BlockCache<any>>(b => b.ancestry, "iterates over all the ancestors", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        const blocks = generateBlocks(10, 0, "main");
-        for (const block of blocks) {
-            await bc.addBlock(block);
-        }
-        const headBlock = blocks[blocks.length - 1];
+        await blockStore.withBatch( async () => {
+            const blocks = generateBlocks(10, 0, "main");
+            for (const block of blocks) {
+                await bc.addBlock(block);
+            }
+            const headBlock = blocks[blocks.length - 1];
 
-        // Add some other blocks in a forked chain at height 3
-        for (const block of generateBlocks(5, 3, "fork", blocks[1].hash)) {
-            await bc.addBlock(block);
-        }
+            // Add some other blocks in a forked chain at height 3
+            for (const block of generateBlocks(5, 3, "fork", blocks[1].hash)) {
+                await bc.addBlock(block);
+            }
 
-        const result = [...bc.ancestry(headBlock.hash)];
-        result.reverse();
+            const result = [...bc.ancestry(headBlock.hash)];
+            result.reverse();
 
-        expect(result).to.deep.equal(blocks);
+            expect(result).to.deep.equal(blocks);
+        });
     });
 
     fnIt<BlockCache<any>>(b => b.findAncestor, "returns the nearest ancestor that satisfies the predicate", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        const blocks = generateBlocks(5, 0, "main");
-        for (const block of blocks) {
-            await bc.addBlock(block);
-        }
-        const headBlock = blocks[blocks.length - 1];
+        await blockStore.withBatch( async () => {
+            const blocks = generateBlocks(5, 0, "main");
+            for (const block of blocks) {
+                await bc.addBlock(block);
+            }
+            const headBlock = blocks[blocks.length - 1];
 
-        const result = bc.findAncestor(headBlock.hash, block => block.hash == blocks[2].hash);
-        expect(result).to.not.be.null;
-        expect(blocks[2]).to.deep.include(result!);
+            const result = bc.findAncestor(headBlock.hash, block => block.hash == blocks[2].hash);
+            expect(result).to.not.be.null;
+            expect(blocks[2]).to.deep.include(result!);
+        });
     });
 
     fnIt<BlockCache<any>>(b => b.findAncestor, "returns self if satisfies the predicate", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        const blocks = generateBlocks(5, 0, "main");
-        for (const block of blocks) {
-            await bc.addBlock(block);
-        }
-        const headBlock = blocks[blocks.length - 1];
+        await blockStore.withBatch( async () => {
+            const blocks = generateBlocks(5, 0, "main");
+            for (const block of blocks) {
+                await bc.addBlock(block);
+            }
+            const headBlock = blocks[blocks.length - 1];
 
-        const result = bc.findAncestor(headBlock.hash, block => block.hash == headBlock.hash);
-        expect(result).to.not.be.null;
-        expect(headBlock).to.deep.include(result!);
+            const result = bc.findAncestor(headBlock.hash, block => block.hash == headBlock.hash);
+            expect(result).to.not.be.null;
+            expect(headBlock).to.deep.include(result!);
+        });
     });
 
     fnIt<BlockCache<any>>(b => b.findAncestor, "returns self if satisfies the predicate", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        const blocks = generateBlocks(5, 0, "main");
-        for (const block of blocks) {
-            await bc.addBlock(block);
-        }
-        const headBlock = blocks[blocks.length - 1];
+        await blockStore.withBatch( async () => {
+            const blocks = generateBlocks(5, 0, "main");
+            for (const block of blocks) {
+                await bc.addBlock(block);
+            }
+            const headBlock = blocks[blocks.length - 1];
 
-        const result = bc.findAncestor(headBlock.hash, block => block.hash == "notExistingHash");
-        expect(result).to.be.null;
+            const result = bc.findAncestor(headBlock.hash, block => block.hash == "notExistingHash");
+            expect(result).to.be.null;
+        });
     });
 
     fnIt<BlockCache<any>>(b => b.findAncestor, "does not return at height less than minHeight", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        const blocks = generateBlocks(5, 0, "main");
-        for (const block of blocks) {
-            await bc.addBlock(block);
-        }
-        const headBlock = blocks[blocks.length - 1];
+        await blockStore.withBatch( async () => {
+            const blocks = generateBlocks(5, 0, "main");
+            for (const block of blocks) {
+                await bc.addBlock(block);
+            }
+            const headBlock = blocks[blocks.length - 1];
 
-        // condition is true only for a block at height strictly below minHeight
-        const result = bc.findAncestor(headBlock.hash, block => block.number === blocks[3].number, blocks[3].number + 1);
-        expect(result).to.be.null;
+            // condition is true only for a block at height strictly below minHeight
+            const result = bc.findAncestor(headBlock.hash, block => block.number === blocks[3].number, blocks[3].number + 1);
+            expect(result).to.be.null;
+        });
     });
 
     fnIt<BlockCache<any>>(b => b.findAncestor, "does return at height equal or more than minHeight", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        const blocks = generateBlocks(5, 0, "main");
-        for (const block of blocks) {
-            await bc.addBlock(block);
-        }
-        const headBlock = blocks[blocks.length - 1];
+        await blockStore.withBatch( async () => {
+            const blocks = generateBlocks(5, 0, "main");
+            for (const block of blocks) {
+                await bc.addBlock(block);
+            }
+            const headBlock = blocks[blocks.length - 1];
 
-        // condition is true only for blocks at height exactly minHeight
-        const result = bc.findAncestor(headBlock.hash, block => block.number === blocks[3].number, blocks[3].number);
-        expect(result).to.not.be.null;
-        expect(blocks[3]).to.deep.include(result!);
+            // condition is true only for blocks at height exactly minHeight
+            const result = bc.findAncestor(headBlock.hash, block => block.number === blocks[3].number, blocks[3].number);
+            expect(result).to.not.be.null;
+            expect(blocks[3]).to.deep.include(result!);
+        });
     });
 
     fnIt<BlockCache<any>>(b => b.getOldestAncestorInCache, "returns the deepest ancestor", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        const blocks = generateBlocks(5, 0, "main");
-        for (const block of blocks) {
-            await bc.addBlock(block);
-        }
-        const headBlock = blocks[blocks.length - 1];
+        await blockStore.withBatch( async () => {
+            const blocks = generateBlocks(5, 0, "main");
+            for (const block of blocks) {
+                await bc.addBlock(block);
+            }
+            const headBlock = blocks[blocks.length - 1];
 
-        const result = bc.getOldestAncestorInCache(headBlock.hash);
-        expect(blocks[0]).to.deep.include(result);
+            const result = bc.getOldestAncestorInCache(headBlock.hash);
+            expect(blocks[0]).to.deep.include(result);
+        });
     });
 
     fnIt<BlockCache<any>>(b => b.getOldestAncestorInCache, "throws ArgumentError for a hash not in cache", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        const blocks = generateBlocks(5, 0, "main");
-        for (const block of blocks) {
-            await bc.addBlock(block);
-        }
-        expect(() => bc.getOldestAncestorInCache("notExistingHash")).to.throw(ArgumentError);
+        await blockStore.withBatch( async () => {
+            const blocks = generateBlocks(5, 0, "main");
+            for (const block of blocks) {
+                await bc.addBlock(block);
+            }
+            expect(() => bc.getOldestAncestorInCache("notExistingHash")).to.throw(ArgumentError);
+        });
     });
 
     fnIt<BlockCache<any>>(b => b.setHead, "correctly sets new head", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        const blocks = generateBlocks(1, 0, "main");
+        await blockStore.withBatch( async () => {
+            const blocks = generateBlocks(1, 0, "main");
 
-        await bc.addBlock(blocks[0]);
-        bc.setHead(blocks[0].hash);
-        expect(bc.head).to.deep.equal(blocks[0]);
+            await bc.addBlock(blocks[0]);
+            bc.setHead(blocks[0].hash);
+            expect(bc.head).to.deep.equal(blocks[0]);
+        });
     });
 
-    fnIt<BlockCache<any>>(b => b.setHead, "setHead throws for head not in cache", () => {
+    fnIt<BlockCache<any>>(b => b.setHead, "setHead throws for head not in cache", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        const blocks = generateBlocks(1, 0, "main");
+        await blockStore.withBatch( async () => {
+            const blocks = generateBlocks(1, 0, "main");
 
-        expect(() => bc.setHead(blocks[0].hash)).to.throw(ArgumentError);
+            expect(() => bc.setHead(blocks[0].hash)).to.throw(ArgumentError);
+        });
     });
 
-    it("head throws if setHead never called", () => {
+    it("head throws if setHead never called", async () => {
         const bc = new BlockCache(maxDepth, blockStore);
-        expect(() => bc.head).to.throw(ApplicationError);
+        await blockStore.withBatch( async () => {
+            expect(() => bc.head).to.throw(ApplicationError);
+        });
     });
 });
 
@@ -473,41 +546,48 @@ describe("getConfirmations", () => {
 
     let db: any;
     let blockStore: BlockItemStore<IBlockStub & TransactionHashes>;
-    beforeEach(() => {
+    beforeEach(async () => {
         db = LevelUp(EncodingDown<string, any>(MemDown(), { valueEncoding: "json" }));
         blockStore = new BlockItemStore<IBlockStub & TransactionHashes>(db);
+        await blockStore.start();
     });
 
     it("correctly computes the number of confirmations for a transaction", async () => {
         const bc = new BlockCache<IBlockStub & TransactionHashes>(maxDepth, blockStore);
-        const blocks = generateBlocks(7, 0, "main"); // must be less blocks than maxDepth
-        for (const block of blocks) {
-            await bc.addBlock(block);
-        }
-        const headBlock = blocks[blocks.length - 1];
-        expect(getConfirmations(bc, headBlock.hash, blocks[0].transactionHashes[0])).to.equal(blocks.length);
-        expect(getConfirmations(bc, headBlock.hash, blocks[1].transactionHashes[0])).to.equal(blocks.length - 1);
+        await blockStore.withBatch( async () => {
+            const blocks = generateBlocks(7, 0, "main"); // must be less blocks than maxDepth
+            for (const block of blocks) {
+                await bc.addBlock(block);
+            }
+            const headBlock = blocks[blocks.length - 1];
+            expect(getConfirmations(bc, headBlock.hash, blocks[0].transactionHashes[0])).to.equal(blocks.length);
+            expect(getConfirmations(bc, headBlock.hash, blocks[1].transactionHashes[0])).to.equal(blocks.length - 1);
+        });
     });
 
     it("correctly returns 0 confirmations if transaction is not known", async () => {
         const bc = new BlockCache<IBlockStub & TransactionHashes>(maxDepth, blockStore);
-        const blocks = generateBlocks(128, 0, "main");
-        for (const block of blocks) {
-            await bc.addBlock(block);
-        }
+        await blockStore.withBatch( async () => {
+            const blocks = generateBlocks(128, 0, "main");
+            for (const block of blocks) {
+                await bc.addBlock(block);
+            }
 
-        const headBlock = blocks[blocks.length - 1];
-        expect(getConfirmations(bc, headBlock.hash, "nonExistingTxHash")).to.equal(0);
+            const headBlock = blocks[blocks.length - 1];
+            expect(getConfirmations(bc, headBlock.hash, "nonExistingTxHash")).to.equal(0);
+        });
     });
 
     it("throws ArgumentError if no block with the given hash is in the BlockCache", async () => {
         const bc = new BlockCache<IBlockStub & TransactionHashes>(maxDepth, blockStore);
-        const blocks = generateBlocks(128, 0, "main");
-        for (const block of blocks) {
-            await bc.addBlock(block);
-        }
+        await blockStore.withBatch( async () => {
+            const blocks = generateBlocks(128, 0, "main");
+            for (const block of blocks) {
+                await bc.addBlock(block);
+            }
 
-        const headBlock = blocks[blocks.length - 1];
-        expect(() => getConfirmations(bc, "nonExistingBlockHash", headBlock.transactionHashes[0])).to.throw(ApplicationError);
+            const headBlock = blocks[blocks.length - 1];
+            expect(() => getConfirmations(bc, "nonExistingBlockHash", headBlock.transactionHashes[0])).to.throw(ApplicationError);
+        });
     });
 });

--- a/test/src/blockMonitor/blockCache.test.ts
+++ b/test/src/blockMonitor/blockCache.test.ts
@@ -19,14 +19,14 @@ function generateBlocks(
     for (let height = initialHeight; height < initialHeight + nBlocks; height++) {
         const transactions: string[] = [];
         for (let i = 0; i < 5; i++) {
-            transactions.push(`${chain}-block${height}tx${i + 1}`);
+        transactions.push(`${chain}-block${height}tx${i + 1}`);
         }
 
         const block = {
-            number: height,
-            hash: `hash-${chain}-${height}`,
-            parentHash: rootParentHash != null && height === initialHeight ? rootParentHash : `hash-${chain}-${height - 1}`,
-            transactionHashes: transactions
+        number: height,
+        hash: `hash-${chain}-${height}`,
+        parentHash: rootParentHash != null && height === initialHeight ? rootParentHash : `hash-${chain}-${height - 1}`,
+        transactionHashes: transactions
         };
 
         result.push(block as (IBlockStub & TransactionHashes));
@@ -55,489 +55,395 @@ describe("BlockCache", () => {
     const maxDepth = 10;
     let db: any;
     let blockStore: BlockItemStore<IBlockStub>;
+    let bc: BlockCache<IBlockStub>;
+
+    let resolveBatch: (value?: any) => void;
+
     beforeEach(async () => {
         db = LevelUp(EncodingDown<string, any>(MemDown(), { valueEncoding: "json" }));
         blockStore = new BlockItemStore<IBlockStub>(db);
+        await blockStore.start();
+
+        bc = new BlockCache(maxDepth, blockStore);
+
+        // Create a batch that will be closed in the afterEach block, as the BlockCache assumes the batch is already open
+        blockStore.withBatch(() => new Promise(resolve => {
+        resolveBatch = resolve;
+        }));
     });
 
-    afterEach(async () => await blockStore.stop());
+    afterEach(async () => {
+        resolveBatch();
+        await Promise.resolve();
+
+        await blockStore.stop();
+    });
 
     it("records a block that was just added", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const blocks = generateBlocks(1, 0, "main");
+        const blocks = generateBlocks(1, 0, "main");
 
-            await bc.addBlock(blocks[0]);
+        await bc.addBlock(blocks[0]);
 
-            expect(blocks[0]).to.deep.include(bc.getBlock(blocks[0].hash));
-        });
+        expect(blocks[0]).to.deep.include(bc.getBlock(blocks[0].hash));
     });
 
     fnIt<BlockCache<any>>(b => b.addBlock, "adds blocks that are attached and returns Added", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const blocks = generateBlocks(10, 5, "main");
-            expect(await bc.addBlock(blocks[0])).to.equal(BlockAddResult.Added);
-            expect(await bc.addBlock(blocks[1])).to.equal(BlockAddResult.Added);
-            expect(await bc.addBlock(blocks[2])).to.equal(BlockAddResult.Added);
-        });
+        const blocks = generateBlocks(10, 5, "main");
+        expect(await bc.addBlock(blocks[0])).to.equal(BlockAddResult.Added);
+        expect(await bc.addBlock(blocks[1])).to.equal(BlockAddResult.Added);
+        expect(await bc.addBlock(blocks[2])).to.equal(BlockAddResult.Added);
     });
 
     fnIt<BlockCache<any>>(b => b.addBlock, "adds unattached blocks and returns false", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const blocks = generateBlocks(10, 5, "main");
-            await bc.addBlock(blocks[0]);
-            expect(await bc.addBlock(blocks[3])).to.equal(BlockAddResult.AddedDetached);
-            expect(await bc.addBlock(blocks[2])).to.equal(BlockAddResult.AddedDetached);
-        });
+        const blocks = generateBlocks(10, 5, "main");
+        await bc.addBlock(blocks[0]);
+        expect(await bc.addBlock(blocks[3])).to.equal(BlockAddResult.AddedDetached);
+        expect(await bc.addBlock(blocks[2])).to.equal(BlockAddResult.AddedDetached);
     });
 
     it("emits a new block event when a new block is added and attached", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const blocks = generateBlocks(10, 5, "main");
+        const blocks = generateBlocks(10, 5, "main");
 
-            const newBlockSpy = new NewBlockSpy();
-            bc.newBlock.addListener(newBlockSpy.newBlockListener);
+        const newBlockSpy = new NewBlockSpy();
+        bc.newBlock.addListener(newBlockSpy.newBlockListener);
 
-            await bc.addBlock(blocks[0]);
+        await bc.addBlock(blocks[0]);
 
-            expect(newBlockSpy.callCounter).to.equal(1);
-            expect(newBlockSpy.lastCallBlock).to.equal(blocks[0]);
-        });
+        expect(newBlockSpy.callCounter).to.equal(1);
+        expect(newBlockSpy.lastCallBlock).to.equal(blocks[0]);
     });
 
     it("does not emit a new block event when a new block is added unattached", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const blocks = generateBlocks(10, 5, "main");
-            await bc.addBlock(blocks[0]);
+        const blocks = generateBlocks(10, 5, "main");
+        await bc.addBlock(blocks[0]);
 
-            const newBlockSpy = new NewBlockSpy();
-            bc.newBlock.addListener(newBlockSpy.newBlockListener);
+        const newBlockSpy = new NewBlockSpy();
+        bc.newBlock.addListener(newBlockSpy.newBlockListener);
 
-            await bc.addBlock(blocks[2]); //unattached block
+        await bc.addBlock(blocks[2]); //unattached block
 
-            expect(newBlockSpy.callCounter).to.equal(0);
-        });
+        expect(newBlockSpy.callCounter).to.equal(0);
     });
 
     it("emits a new block event when an unattached block becomes attached", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const blocks = generateBlocks(10, 5, "main");
-            await bc.addBlock(blocks[0]);
+        const blocks = generateBlocks(10, 5, "main");
+        await bc.addBlock(blocks[0]);
 
-            const newBlockSpy = new NewBlockSpy();
-            bc.newBlock.addListener(newBlockSpy.newBlockListener);
+        const newBlockSpy = new NewBlockSpy();
+        bc.newBlock.addListener(newBlockSpy.newBlockListener);
 
-            await bc.addBlock(blocks[2]); //unattached block
-            await bc.addBlock(blocks[1]); //now both blocks become attached
+        await bc.addBlock(blocks[2]); //unattached block
+        await bc.addBlock(blocks[1]); //now both blocks become attached
 
-            expect(newBlockSpy.callCounter).to.equal(2);
-            expect(newBlockSpy.lastCallBlock).to.deep.equal(blocks[2]);
-        });
+        expect(newBlockSpy.callCounter).to.equal(2);
+        expect(newBlockSpy.lastCallBlock).to.deep.equal(blocks[2]);
     });
 
     fnIt<BlockCache<any>>(b => b.hasBlock, "returns true for an existing attached block", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const blocks = generateBlocks(10, 5, "main");
-            await bc.addBlock(blocks[0]);
-            await bc.addBlock(blocks[1]);
-            expect(bc.hasBlock(blocks[1].hash)).to.be.true;
-        });
+        const blocks = generateBlocks(10, 5, "main");
+        await bc.addBlock(blocks[0]);
+        await bc.addBlock(blocks[1]);
+        expect(bc.hasBlock(blocks[1].hash)).to.be.true;
     });
 
     fnIt<BlockCache<any>>(b => b.hasBlock, "returns false for a non-existing block", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const blocks = generateBlocks(10, 5, "main");
-            await bc.addBlock(blocks[0]);
-            await bc.addBlock(blocks[1]);
-            expect(bc.hasBlock("someNonExistingHash")).to.be.false;
-        });
+        const blocks = generateBlocks(10, 5, "main");
+        await bc.addBlock(blocks[0]);
+        await bc.addBlock(blocks[1]);
+        expect(bc.hasBlock("someNonExistingHash")).to.be.false;
     });
 
     fnIt<BlockCache<any>>(b => b.hasBlock, "returns false for an unattached block if allowPending=false", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const blocks = generateBlocks(10, 5, "main");
-            await bc.addBlock(blocks[0]);
-            await bc.addBlock(blocks[1]);
-            await bc.addBlock(blocks[3]);
-            expect(bc.hasBlock(blocks[3].hash, false)).to.be.false;
-        });
+        const blocks = generateBlocks(10, 5, "main");
+        await bc.addBlock(blocks[0]);
+        await bc.addBlock(blocks[1]);
+        await bc.addBlock(blocks[3]);
+        expect(bc.hasBlock(blocks[3].hash, false)).to.be.false;
     });
 
     fnIt<BlockCache<any>>(b => b.hasBlock, "returns true for an unattached block if allowPending=true", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const blocks = generateBlocks(10, 5, "main");
-            await bc.addBlock(blocks[0]);
-            await bc.addBlock(blocks[1]);
-            await bc.addBlock(blocks[3]);
-            expect(bc.hasBlock(blocks[3].hash, true)).to.be.true;
-        });
+        const blocks = generateBlocks(10, 5, "main");
+        await bc.addBlock(blocks[0]);
+        await bc.addBlock(blocks[1]);
+        await bc.addBlock(blocks[3]);
+        expect(bc.hasBlock(blocks[3].hash, true)).to.be.true;
     });
 
     fnIt<BlockCache<any>>(b => b.addBlock, "makes sure that a previously unattached block becomes attached if appropriate", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const blocks = generateBlocks(10, 5, "main");
-            await bc.addBlock(blocks[0]);
-            await bc.addBlock(blocks[3]);
-            await bc.addBlock(blocks[2]);
+        const blocks = generateBlocks(10, 5, "main");
+        await bc.addBlock(blocks[0]);
+        await bc.addBlock(blocks[3]);
+        await bc.addBlock(blocks[2]);
 
-            expect(await bc.addBlock(blocks[1])).to.equal(BlockAddResult.Added);
+        expect(await bc.addBlock(blocks[1])).to.equal(BlockAddResult.Added);
 
-            expect(bc.maxHeight).to.equal(blocks[3].number);
-            expect(bc.hasBlock(blocks[3].hash)).to.be.true;
-        });
+        expect(bc.maxHeight).to.equal(blocks[3].number);
+        expect(bc.hasBlock(blocks[3].hash)).to.be.true;
     });
 
     it("maxHeight does not change for unattached blocks", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const blocks = generateBlocks(10, 5, "main");
-            await bc.addBlock(blocks[0]);
-            await bc.addBlock(blocks[3]);
-            expect(bc.maxHeight).to.equal(blocks[0].number);
-        });
+        const blocks = generateBlocks(10, 5, "main");
+        await bc.addBlock(blocks[0]);
+        await bc.addBlock(blocks[3]);
+        expect(bc.maxHeight).to.equal(blocks[0].number);
     });
 
     fnIt<BlockCache<any>>(b => b.getBlock, "returns an attached block", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const blocks = generateBlocks(10, 5, "main");
-            await bc.addBlock(blocks[0]);
-            await bc.addBlock(blocks[1]);
-            await bc.addBlock(blocks[3]);
-            expect(bc.getBlock(blocks[1].hash)).to.deep.equal(blocks[1]);
-        });
+        const blocks = generateBlocks(10, 5, "main");
+        await bc.addBlock(blocks[0]);
+        await bc.addBlock(blocks[1]);
+        await bc.addBlock(blocks[3]);
+        expect(bc.getBlock(blocks[1].hash)).to.deep.equal(blocks[1]);
     });
 
     fnIt<BlockCache<any>>(b => b.getBlock, "returns an unattached block", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const blocks = generateBlocks(10, 5, "main");
-            await bc.addBlock(blocks[0]);
-            await bc.addBlock(blocks[1]);
-            await bc.addBlock(blocks[3]);
-            expect(bc.getBlock(blocks[3].hash)).to.deep.equal(blocks[3]);
-        });
+        const blocks = generateBlocks(10, 5, "main");
+        await bc.addBlock(blocks[0]);
+        await bc.addBlock(blocks[1]);
+        await bc.addBlock(blocks[3]);
+        expect(bc.getBlock(blocks[3].hash)).to.deep.equal(blocks[3]);
     });
 
     fnIt<BlockCache<any>>(b => b.getBlock, "throws ApplicationError for an unknown block", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const blocks = generateBlocks(10, 5, "main");
-            await bc.addBlock(blocks[0]);
-            await bc.addBlock(blocks[1]);
-            await bc.addBlock(blocks[3]);
-            expect(() => bc.getBlock("someNonExistingHash")).to.throw(ApplicationError);
-        });
+        const blocks = generateBlocks(10, 5, "main");
+        await bc.addBlock(blocks[0]);
+        await bc.addBlock(blocks[1]);
+        await bc.addBlock(blocks[3]);
+        expect(() => bc.getBlock("someNonExistingHash")).to.throw(ApplicationError);
     });
 
     it("minHeight is equal to the initial block height if less then maxDepth blocks are added", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const initialHeight = 3;
-            const blocks = generateBlocks(maxDepth - 1, initialHeight, "main");
+        const initialHeight = 3;
+        const blocks = generateBlocks(maxDepth - 1, initialHeight, "main");
 
-            for (const block of blocks) {
-                await bc.addBlock(block);
-            }
+        for (const block of blocks) {
+            await bc.addBlock(block);
+        }
 
-            expect(bc.minHeight).to.equal(initialHeight);
-        });
+        expect(bc.minHeight).to.equal(initialHeight);
     });
 
     it("minHeight is equal to the height of the highest added block minus maxDepth if more than maxDepth blocks are added", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const initialHeight = 3;
-            const blocksAdded = 2 * maxDepth;
-            const lastBlockAdded = initialHeight + blocksAdded - 1;
-            const blocks = generateBlocks(blocksAdded, initialHeight, "main");
-            for (const block of blocks) {
-                await bc.addBlock(block);
-            }
-            expect(bc.minHeight).to.equal(lastBlockAdded - maxDepth);
-        });
+        const initialHeight = 3;
+        const blocksAdded = 2 * maxDepth;
+        const lastBlockAdded = initialHeight + blocksAdded - 1;
+        const blocks = generateBlocks(blocksAdded, initialHeight, "main");
+        for (const block of blocks) {
+            await bc.addBlock(block);
+        }
+        expect(bc.minHeight).to.equal(lastBlockAdded - maxDepth);
     });
 
     it("maxHeight is equal to the height of the highest added block", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const initialHeight = 3;
-            const blocksAdded = 2 * maxDepth;
-            const lastBlockAdded = initialHeight + blocksAdded - 1;
+        const initialHeight = 3;
+        const blocksAdded = 2 * maxDepth;
+        const lastBlockAdded = initialHeight + blocksAdded - 1;
 
-            // Add some blocks
-            for (const block of generateBlocks(blocksAdded, initialHeight, "main")) {
-                await bc.addBlock(block);
-            }
-            // Add a shorter separate chain
-            for (const block of generateBlocks(blocksAdded - 1, initialHeight, "forkedchain")) {
-                await bc.addBlock(block);
-            }
+        // Add some blocks
+        for (const block of generateBlocks(blocksAdded, initialHeight, "main")) {
+            await bc.addBlock(block);
+        }
+        // Add a shorter separate chain
+        for (const block of generateBlocks(blocksAdded - 1, initialHeight, "forkedchain")) {
+            await bc.addBlock(block);
+        }
 
-            expect(bc.maxHeight).to.equal(lastBlockAdded);
-        });
+        expect(bc.maxHeight).to.equal(lastBlockAdded);
     });
 
     fnIt<BlockCache<any>>(b => b.canAttachBlock, "returns true for blocks whose height is equal to the initial height", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
 
-            const blocks = generateBlocks(10, 5, "main");
-            const otherBlocks = generateBlocks(10, 5, "other");
+        const blocks = generateBlocks(10, 5, "main");
+        const otherBlocks = generateBlocks(10, 5, "other");
 
-            await bc.addBlock(blocks[3]);
+        await bc.addBlock(blocks[3]);
 
-            expect(bc.canAttachBlock(blocks[3])).to.be.true;
-            expect(bc.canAttachBlock(otherBlocks[3])).to.be.true;
-        });
+        expect(bc.canAttachBlock(blocks[3])).to.be.true;
+        expect(bc.canAttachBlock(otherBlocks[3])).to.be.true;
     });
 
     fnIt<BlockCache<any>>(b => b.canAttachBlock, "returns false for blocks whose height is lower than the initial height", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
 
-            const blocks = generateBlocks(10, 5, "main");
-            const otherBlocks = generateBlocks(10, 5, "other");
+        const blocks = generateBlocks(10, 5, "main");
+        const otherBlocks = generateBlocks(10, 5, "other");
 
-            await bc.addBlock(blocks[3]);
+        await bc.addBlock(blocks[3]);
 
-            expect(bc.canAttachBlock(blocks[2])).to.be.false;
-            expect(bc.canAttachBlock(otherBlocks[2])).to.be.false;
-        });
+        expect(bc.canAttachBlock(blocks[2])).to.be.false;
+        expect(bc.canAttachBlock(otherBlocks[2])).to.be.false;
     });
 
     fnIt<BlockCache<any>>(b => b.canAttachBlock, "returns true for a block whose height is equal to the maximum depth", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const initialHeight = 3;
-            const blocksAdded = maxDepth + 1;
-            const blocks = generateBlocks(blocksAdded, initialHeight, "main");
-            for (const block of blocks) {
-                await bc.addBlock(block);
-            }
-            const otherBlocks = generateBlocks(2, initialHeight - 1, "main");
+        const initialHeight = 3;
+        const blocksAdded = maxDepth + 1;
+        const blocks = generateBlocks(blocksAdded, initialHeight, "main");
+        for (const block of blocks) {
+            await bc.addBlock(block);
+        }
+        const otherBlocks = generateBlocks(2, initialHeight - 1, "main");
 
-            expect(bc.canAttachBlock(otherBlocks[1])).to.be.true;
-        });
+        expect(bc.canAttachBlock(otherBlocks[1])).to.be.true;
     });
 
     fnIt<BlockCache<any>>(b => b.canAttachBlock, "returns false for blocks whose height is lower than the maximum depth", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const initialHeight = 3;
-            const blocksAdded = maxDepth + 1;
-            const blocks = generateBlocks(blocksAdded, initialHeight, "main");
-            for (const block of blocks) {
-                await bc.addBlock(block);
-            }
-            const otherBlocks = generateBlocks(2, initialHeight - 1, "main");
+        const initialHeight = 3;
+        const blocksAdded = maxDepth + 1;
+        const blocks = generateBlocks(blocksAdded, initialHeight, "main");
+        for (const block of blocks) {
+            await bc.addBlock(block);
+        }
+        const otherBlocks = generateBlocks(2, initialHeight - 1, "main");
 
-            expect(bc.canAttachBlock(otherBlocks[0])).to.be.false;
-        });
+        expect(bc.canAttachBlock(otherBlocks[0])).to.be.false;
     });
 
     fnIt<BlockCache<any>>(b => b.canAttachBlock, "returns true for a block whose parent is in the BlockCache", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const blocks = generateBlocks(10, 7, "main");
+        const blocks = generateBlocks(10, 7, "main");
 
-            await bc.addBlock(blocks[5]);
+        await bc.addBlock(blocks[5]);
 
-            expect(bc.canAttachBlock(blocks[6])).to.be.true;
-        });
+        expect(bc.canAttachBlock(blocks[6])).to.be.true;
     });
 
     fnIt<BlockCache<any>>(b => b.canAttachBlock, "returns false for a block above minHeight whose parent is not in the BlockCache", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const blocks = generateBlocks(10, 7, "main");
+        const blocks = generateBlocks(10, 7, "main");
 
-            await bc.addBlock(blocks[0]);
-            await bc.addBlock(blocks[1]);
-            await bc.addBlock(blocks[2]);
+        await bc.addBlock(blocks[0]);
+        await bc.addBlock(blocks[1]);
+        await bc.addBlock(blocks[2]);
 
-            expect(bc.canAttachBlock(blocks[4])).to.be.false;
-        });
+        expect(bc.canAttachBlock(blocks[4])).to.be.false;
     });
 
     it("records blocks until maximum depth", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const blocks = generateBlocks(maxDepth, 0, "main");
-            for (const block of blocks) {
-                await bc.addBlock(block);
-            }
-            expect(blocks[0]).to.deep.include(bc.getBlock(blocks[0].hash));
-        });
+        const blocks = generateBlocks(maxDepth, 0, "main");
+        for (const block of blocks) {
+            await bc.addBlock(block);
+        }
+        expect(blocks[0]).to.deep.include(bc.getBlock(blocks[0].hash));
     });
 
     it("forgets blocks past the maximum depth", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const blocks = generateBlocks(maxDepth + 2, 0, "main"); // head is depth 0, so first pruned is maxDepth + 2
-            for (const block of blocks) {
-                await bc.addBlock(block);
-            }
-            expect(() => bc.getBlock(blocks[0].hash)).to.throw(ApplicationError);
-        });
+        const blocks = generateBlocks(maxDepth + 2, 0, "main"); // head is depth 0, so first pruned is maxDepth + 2
+        for (const block of blocks) {
+            await bc.addBlock(block);
+        }
+        expect(() => bc.getBlock(blocks[0].hash)).to.throw(ApplicationError);
     });
 
     fnIt<BlockCache<any>>(b => b.ancestry, "iterates over all the ancestors", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const blocks = generateBlocks(10, 0, "main");
-            for (const block of blocks) {
-                await bc.addBlock(block);
-            }
-            const headBlock = blocks[blocks.length - 1];
+        const blocks = generateBlocks(10, 0, "main");
+        for (const block of blocks) {
+            await bc.addBlock(block);
+        }
+        const headBlock = blocks[blocks.length - 1];
 
-            // Add some other blocks in a forked chain at height 3
-            for (const block of generateBlocks(5, 3, "fork", blocks[1].hash)) {
-                await bc.addBlock(block);
-            }
+        // Add some other blocks in a forked chain at height 3
+        for (const block of generateBlocks(5, 3, "fork", blocks[1].hash)) {
+            await bc.addBlock(block);
+        }
 
-            const result = [...bc.ancestry(headBlock.hash)];
-            result.reverse();
+        const result = [...bc.ancestry(headBlock.hash)];
+        result.reverse();
 
-            expect(result).to.deep.equal(blocks);
-        });
+        expect(result).to.deep.equal(blocks);
     });
 
     fnIt<BlockCache<any>>(b => b.findAncestor, "returns the nearest ancestor that satisfies the predicate", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const blocks = generateBlocks(5, 0, "main");
-            for (const block of blocks) {
-                await bc.addBlock(block);
-            }
-            const headBlock = blocks[blocks.length - 1];
+        const blocks = generateBlocks(5, 0, "main");
+        for (const block of blocks) {
+            await bc.addBlock(block);
+        }
+        const headBlock = blocks[blocks.length - 1];
 
-            const result = bc.findAncestor(headBlock.hash, block => block.hash == blocks[2].hash);
-            expect(result).to.not.be.null;
-            expect(blocks[2]).to.deep.include(result!);
-        });
+        const result = bc.findAncestor(headBlock.hash, block => block.hash == blocks[2].hash);
+        expect(result).to.not.be.null;
+        expect(blocks[2]).to.deep.include(result!);
     });
 
     fnIt<BlockCache<any>>(b => b.findAncestor, "returns self if satisfies the predicate", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const blocks = generateBlocks(5, 0, "main");
-            for (const block of blocks) {
-                await bc.addBlock(block);
-            }
-            const headBlock = blocks[blocks.length - 1];
+        const blocks = generateBlocks(5, 0, "main");
+        for (const block of blocks) {
+            await bc.addBlock(block);
+        }
+        const headBlock = blocks[blocks.length - 1];
 
-            const result = bc.findAncestor(headBlock.hash, block => block.hash == headBlock.hash);
-            expect(result).to.not.be.null;
-            expect(headBlock).to.deep.include(result!);
-        });
+        const result = bc.findAncestor(headBlock.hash, block => block.hash == headBlock.hash);
+        expect(result).to.not.be.null;
+        expect(headBlock).to.deep.include(result!);
     });
 
     fnIt<BlockCache<any>>(b => b.findAncestor, "returns self if satisfies the predicate", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const blocks = generateBlocks(5, 0, "main");
-            for (const block of blocks) {
-                await bc.addBlock(block);
-            }
-            const headBlock = blocks[blocks.length - 1];
+        const blocks = generateBlocks(5, 0, "main");
+        for (const block of blocks) {
+            await bc.addBlock(block);
+        }
+        const headBlock = blocks[blocks.length - 1];
 
-            const result = bc.findAncestor(headBlock.hash, block => block.hash == "notExistingHash");
-            expect(result).to.be.null;
-        });
+        const result = bc.findAncestor(headBlock.hash, block => block.hash == "notExistingHash");
+        expect(result).to.be.null;
     });
 
     fnIt<BlockCache<any>>(b => b.findAncestor, "does not return at height less than minHeight", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const blocks = generateBlocks(5, 0, "main");
-            for (const block of blocks) {
-                await bc.addBlock(block);
-            }
-            const headBlock = blocks[blocks.length - 1];
+        const blocks = generateBlocks(5, 0, "main");
+        for (const block of blocks) {
+            await bc.addBlock(block);
+        }
+        const headBlock = blocks[blocks.length - 1];
 
-            // condition is true only for a block at height strictly below minHeight
-            const result = bc.findAncestor(headBlock.hash, block => block.number === blocks[3].number, blocks[3].number + 1);
-            expect(result).to.be.null;
-        });
+        // condition is true only for a block at height strictly below minHeight
+        const result = bc.findAncestor(headBlock.hash, block => block.number === blocks[3].number, blocks[3].number + 1);
+        expect(result).to.be.null;
     });
 
     fnIt<BlockCache<any>>(b => b.findAncestor, "does return at height equal or more than minHeight", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const blocks = generateBlocks(5, 0, "main");
-            for (const block of blocks) {
-                await bc.addBlock(block);
-            }
-            const headBlock = blocks[blocks.length - 1];
+        const blocks = generateBlocks(5, 0, "main");
+        for (const block of blocks) {
+            await bc.addBlock(block);
+        }
+        const headBlock = blocks[blocks.length - 1];
 
-            // condition is true only for blocks at height exactly minHeight
-            const result = bc.findAncestor(headBlock.hash, block => block.number === blocks[3].number, blocks[3].number);
-            expect(result).to.not.be.null;
-            expect(blocks[3]).to.deep.include(result!);
-        });
+        // condition is true only for blocks at height exactly minHeight
+        const result = bc.findAncestor(headBlock.hash, block => block.number === blocks[3].number, blocks[3].number);
+        expect(result).to.not.be.null;
+        expect(blocks[3]).to.deep.include(result!);
     });
 
     fnIt<BlockCache<any>>(b => b.getOldestAncestorInCache, "returns the deepest ancestor", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const blocks = generateBlocks(5, 0, "main");
-            for (const block of blocks) {
-                await bc.addBlock(block);
-            }
-            const headBlock = blocks[blocks.length - 1];
+        const blocks = generateBlocks(5, 0, "main");
+        for (const block of blocks) {
+            await bc.addBlock(block);
+        }
+        const headBlock = blocks[blocks.length - 1];
 
-            const result = bc.getOldestAncestorInCache(headBlock.hash);
-            expect(blocks[0]).to.deep.include(result);
-        });
+        const result = bc.getOldestAncestorInCache(headBlock.hash);
+        expect(blocks[0]).to.deep.include(result);
     });
 
     fnIt<BlockCache<any>>(b => b.getOldestAncestorInCache, "throws ArgumentError for a hash not in cache", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const blocks = generateBlocks(5, 0, "main");
-            for (const block of blocks) {
-                await bc.addBlock(block);
-            }
-            expect(() => bc.getOldestAncestorInCache("notExistingHash")).to.throw(ArgumentError);
-        });
+        const blocks = generateBlocks(5, 0, "main");
+        for (const block of blocks) {
+            await bc.addBlock(block);
+        }
+        expect(() => bc.getOldestAncestorInCache("notExistingHash")).to.throw(ArgumentError);
     });
 
     fnIt<BlockCache<any>>(b => b.setHead, "correctly sets new head", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const blocks = generateBlocks(1, 0, "main");
+        const blocks = generateBlocks(1, 0, "main");
 
-            await bc.addBlock(blocks[0]);
-            bc.setHead(blocks[0].hash);
-            expect(bc.head).to.deep.equal(blocks[0]);
-        });
+        await bc.addBlock(blocks[0]);
+        bc.setHead(blocks[0].hash);
+        expect(bc.head).to.deep.equal(blocks[0]);
     });
 
     fnIt<BlockCache<any>>(b => b.setHead, "setHead throws for head not in cache", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const blocks = generateBlocks(1, 0, "main");
+        const blocks = generateBlocks(1, 0, "main");
 
-            expect(() => bc.setHead(blocks[0].hash)).to.throw(ArgumentError);
-        });
+        expect(() => bc.setHead(blocks[0].hash)).to.throw(ArgumentError);
     });
 
     it("head throws if setHead never called", async () => {
-        const bc = new BlockCache(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            expect(() => bc.head).to.throw(ApplicationError);
-        });
+        expect(() => bc.head).to.throw(ApplicationError);
     });
 });
 
@@ -546,48 +452,57 @@ describe("getConfirmations", () => {
 
     let db: any;
     let blockStore: BlockItemStore<IBlockStub & TransactionHashes>;
+
+    let bc: BlockCache<IBlockStub & TransactionHashes>;
+
+    let resolveBatch: (value?: any) => void;
     beforeEach(async () => {
         db = LevelUp(EncodingDown<string, any>(MemDown(), { valueEncoding: "json" }));
         blockStore = new BlockItemStore<IBlockStub & TransactionHashes>(db);
         await blockStore.start();
+
+        bc = new BlockCache(maxDepth, blockStore);
+
+        // Create a batch that will be closed in the afterEach block, as the BlockCache assumes the batch is already open
+        blockStore.withBatch(() => new Promise(resolve => {
+            resolveBatch = resolve;
+        }));
+    });
+
+    afterEach(async () => {
+        resolveBatch();
+        await Promise.resolve();
+
+        await blockStore.stop();
     });
 
     it("correctly computes the number of confirmations for a transaction", async () => {
-        const bc = new BlockCache<IBlockStub & TransactionHashes>(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const blocks = generateBlocks(7, 0, "main"); // must be less blocks than maxDepth
-            for (const block of blocks) {
-                await bc.addBlock(block);
-            }
-            const headBlock = blocks[blocks.length - 1];
-            expect(getConfirmations(bc, headBlock.hash, blocks[0].transactionHashes[0])).to.equal(blocks.length);
-            expect(getConfirmations(bc, headBlock.hash, blocks[1].transactionHashes[0])).to.equal(blocks.length - 1);
-        });
+        const blocks = generateBlocks(7, 0, "main"); // must be less blocks than maxDepth
+        for (const block of blocks) {
+            await bc.addBlock(block);
+        }
+        const headBlock = blocks[blocks.length - 1];
+        expect(getConfirmations(bc, headBlock.hash, blocks[0].transactionHashes[0])).to.equal(blocks.length);
+        expect(getConfirmations(bc, headBlock.hash, blocks[1].transactionHashes[0])).to.equal(blocks.length - 1);
     });
 
     it("correctly returns 0 confirmations if transaction is not known", async () => {
-        const bc = new BlockCache<IBlockStub & TransactionHashes>(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const blocks = generateBlocks(128, 0, "main");
-            for (const block of blocks) {
-                await bc.addBlock(block);
-            }
+        const blocks = generateBlocks(128, 0, "main");
+        for (const block of blocks) {
+            await bc.addBlock(block);
+        }
 
-            const headBlock = blocks[blocks.length - 1];
-            expect(getConfirmations(bc, headBlock.hash, "nonExistingTxHash")).to.equal(0);
-        });
+        const headBlock = blocks[blocks.length - 1];
+        expect(getConfirmations(bc, headBlock.hash, "nonExistingTxHash")).to.equal(0);
     });
 
     it("throws ArgumentError if no block with the given hash is in the BlockCache", async () => {
-        const bc = new BlockCache<IBlockStub & TransactionHashes>(maxDepth, blockStore);
-        await blockStore.withBatch( async () => {
-            const blocks = generateBlocks(128, 0, "main");
-            for (const block of blocks) {
-                await bc.addBlock(block);
-            }
+        const blocks = generateBlocks(128, 0, "main");
+        for (const block of blocks) {
+            await bc.addBlock(block);
+        }
 
-            const headBlock = blocks[blocks.length - 1];
-            expect(() => getConfirmations(bc, "nonExistingBlockHash", headBlock.transactionHashes[0])).to.throw(ApplicationError);
-        });
+        const headBlock = blocks[blocks.length - 1];
+        expect(() => getConfirmations(bc, "nonExistingBlockHash", headBlock.transactionHashes[0])).to.throw(ApplicationError);
     });
 });

--- a/test/src/blockMonitor/blockProcessor.test.ts
+++ b/test/src/blockMonitor/blockProcessor.test.ts
@@ -357,7 +357,7 @@ describe("BlockProcessor", () => {
         blockProcessor = new BlockProcessor(provider, blockStubAndTxFactory, blockCache, blockStore, blockProcessorStore);
         emitBlockHash("a1");
         await blockProcessor.start();
-        blockProcessor.addNewHeadListener(async (block: IBlockStub) => {
+        blockProcessor.newHead.addListener(async (block: IBlockStub) => {
             if (block.hash === "a3") throw new Error("Some very serious error");
         });
 

--- a/test/src/blockMonitor/blockProcessor.test.ts
+++ b/test/src/blockMonitor/blockProcessor.test.ts
@@ -183,7 +183,7 @@ describe("BlockProcessor", () => {
     it("correctly processes the blockchain head after startup", async () => {
         emitBlockHash("a1");
 
-        blockProcessor = new BlockProcessor(provider, blockStubAndTxFactory, blockCache, blockProcessorStore);
+        blockProcessor = new BlockProcessor(provider, blockStubAndTxFactory, blockCache, blockStore, blockProcessorStore);
         await blockProcessor.start();
 
         expect(blockProcessor.blockCache.head.hash).to.equal("a1");
@@ -192,7 +192,7 @@ describe("BlockProcessor", () => {
     it("adds the first block received to the cache and emits a new head event after the corresponding new block events from the BlockCache", async () => {
         emitBlockHash("a4");
 
-        blockProcessor = new BlockProcessor(provider, blockStubAndTxFactory, blockCache, blockProcessorStore);
+        blockProcessor = new BlockProcessor(provider, blockStubAndTxFactory, blockCache, blockStore, blockProcessorStore);
         await blockProcessor.start();
 
         let newHeadCalled = false;
@@ -227,7 +227,7 @@ describe("BlockProcessor", () => {
     });
 
     it("adds to the blockCache all ancestors until a known block", async () => {
-        blockProcessor = new BlockProcessor(provider, blockStubAndTxFactory, blockCache, blockProcessorStore);
+        blockProcessor = new BlockProcessor(provider, blockStubAndTxFactory, blockCache, blockStore, blockProcessorStore);
 
         const subscribers = [];
         for (let i = 1; i <= 5; i++) {
@@ -250,7 +250,7 @@ describe("BlockProcessor", () => {
     });
 
     it("adds both chain until the common ancestor if there is a fork", async () => {
-        blockProcessor = new BlockProcessor(provider, blockStubAndTxFactory, blockCache, blockProcessorStore);
+        blockProcessor = new BlockProcessor(provider, blockStubAndTxFactory, blockCache, blockStore, blockProcessorStore);
 
         const subscribersA = [];
         for (let i = 1; i <= 6; i++) {
@@ -290,7 +290,7 @@ describe("BlockProcessor", () => {
     // namely the parent of a known block.
     // This situation occurred in tests on Ropsten using Infura, see https://github.com/PISAresearch/pisa/issues/227.
     it("resumes adding blocks after a previous failure when a new block is emitted", async () => {
-        blockProcessor = new BlockProcessor(provider, blockStubAndTxFactory, blockCache, blockProcessorStore);
+        blockProcessor = new BlockProcessor(provider, blockStubAndTxFactory, blockCache, blockStore, blockProcessorStore);
 
         emitBlockHash("a1");
 
@@ -322,7 +322,7 @@ describe("BlockProcessor", () => {
     // While documentation of ethers.js does not currently state this possibility, this situation occurred in tests on Ropsten using Infura,
     // see https://github.com/PISAresearch/pisa/issues/227.
     it("resumes adding blocks after a previous failure due to getBlock throwing an error when a new block is emitted", async () => {
-        blockProcessor = new BlockProcessor(provider, blockStubAndTxFactory, blockCache, blockProcessorStore);
+        blockProcessor = new BlockProcessor(provider, blockStubAndTxFactory, blockCache, blockStore, blockProcessorStore);
 
         emitBlockHash("a1");
 

--- a/test/src/dataEntities/block.test.ts
+++ b/test/src/dataEntities/block.test.ts
@@ -113,7 +113,7 @@ describe("BlockItemStore", () => {
         expect(storedItem).to.deep.equal(sampleValue);
     });
 
-    fnIt<BlockItemStore<any>>(b => b.putBlockItem, "throws ApplicationError if no executed within a withBatch callback", async () => {
+    fnIt<BlockItemStore<any>>(b => b.putBlockItem, "throws ApplicationError if not executed within a withBatch callback", async () => {
         expect(() => store.putBlockItem(42, "0x424242", "test", {})).to.throw(ApplicationError);
     });
 

--- a/test/src/dataEntities/block.test.ts
+++ b/test/src/dataEntities/block.test.ts
@@ -83,12 +83,12 @@ describe("BlockItemStore", () => {
     async function addSampleData(bis: BlockItemStore<IBlockStub>) {
         await store.withBatch(
             async () => {
-                await bis.putBlockItem(block10a.number, block10a.hash, "block", block10a);
-                await bis.putBlockItem(block10a.number, block10a.hash, "attached", true);
-                await bis.putBlockItem(block42.number, block42.hash, "block", block42);
-                await bis.putBlockItem(block42.number, block42.hash, "attached", true);
-                await bis.putBlockItem(block10b.number, block10b.hash, "block", block10b);
-                await bis.putBlockItem(block10b.number, block10b.hash, "attached", false);
+                bis.putBlockItem(block10a.number, block10a.hash, "block", block10a);
+                bis.putBlockItem(block10a.number, block10a.hash, "attached", true);
+                bis.putBlockItem(block42.number, block42.hash, "block", block42);
+                bis.putBlockItem(block42.number, block42.hash, "attached", true);
+                bis.putBlockItem(block10b.number, block10b.hash, "block", block10b);
+                bis.putBlockItem(block10b.number, block10b.hash, "attached", false);
            }
         );
     }
@@ -108,7 +108,7 @@ describe("BlockItemStore", () => {
             async () => store.putBlockItem(sampleBlocks[0].number, sampleBlocks[0].hash, sampleKey, sampleValue)
         );
 
-        const storedItem = await store.getItem(sampleBlocks[0].hash, sampleKey);
+        const storedItem = store.getItem(sampleBlocks[0].hash, sampleKey);
 
         expect(storedItem).to.deep.equal(sampleValue);
     });
@@ -132,12 +132,12 @@ describe("BlockItemStore", () => {
         await store.withBatch(async () => store.deleteItemsAtHeight(10));
 
         // Check that all items at height 10 return undefined, but all the others are not changed
-        expect(await store.getItem(block10a.hash, "block")).to.be.undefined;
-        expect(await store.getItem(block10a.hash, "attached")).to.be.undefined;
-        expect(await store.getItem(block42.hash, "block")).to.deep.include(block42);
-        expect(await store.getItem(block42.hash, "attached")).to.be.true;
-        expect(await store.getItem(block10b.hash, "block")).to.be.undefined;
-        expect(await store.getItem(block10b.hash, "attached")).to.be.undefined;
+        expect(store.getItem(block10a.hash, "block")).to.be.undefined;
+        expect(store.getItem(block10a.hash, "attached")).to.be.undefined;
+        expect(store.getItem(block42.hash, "block")).to.deep.include(block42);
+        expect(store.getItem(block42.hash, "attached")).to.be.true;
+        expect(store.getItem(block10b.hash, "block")).to.be.undefined;
+        expect(store.getItem(block10b.hash, "attached")).to.be.undefined;
     });
 
     it("actually persists items into the database", async () => {
@@ -149,11 +149,11 @@ describe("BlockItemStore", () => {
         await newStore.start();
 
         // Check that all items still return the correct value for the new store
-        expect(await newStore.getItem(block10a.hash, "block")).to.deep.include(block10a);
-        expect(await newStore.getItem(block10a.hash, "attached")).to.be.true;
-        expect(await newStore.getItem(block42.hash, "block")).to.deep.include(block42);
-        expect(await newStore.getItem(block42.hash, "attached")).to.be.true;
-        expect(await newStore.getItem(block10b.hash, "block")).to.deep.include(block10b);
-        expect(await newStore.getItem(block10b.hash, "attached")).to.be.false;
+        expect(newStore.getItem(block10a.hash, "block")).to.deep.include(block10a);
+        expect(newStore.getItem(block10a.hash, "attached")).to.be.true;
+        expect(newStore.getItem(block42.hash, "block")).to.deep.include(block42);
+        expect(newStore.getItem(block42.hash, "attached")).to.be.true;
+        expect(newStore.getItem(block10b.hash, "block")).to.deep.include(block10b);
+        expect(newStore.getItem(block10b.hash, "attached")).to.be.false;
     });
 });

--- a/test/src/dataEntities/block.test.ts
+++ b/test/src/dataEntities/block.test.ts
@@ -6,7 +6,7 @@ import EncodingDown from "encoding-down";
 import MemDown from "memdown";
 
 import { hasLogMatchingEventFilter, IBlockStub, Logs, BlockItemStore } from "../../../src/dataEntities/block";
-import { ArgumentError } from "../../../src/dataEntities";
+import { ArgumentError, ApplicationError } from "../../../src/dataEntities";
 import fnIt from "../../utils/fnIt";
 
 describe("hasLogMatchingEventFilter", () => {
@@ -111,6 +111,15 @@ describe("BlockItemStore", () => {
         const storedItem = store.getItem(sampleBlocks[0].hash, sampleKey);
 
         expect(storedItem).to.deep.equal(sampleValue);
+    });
+
+    fnIt<BlockItemStore<any>>(b => b.putBlockItem, "throws ApplicationError if no executed within a withBatch callback", async () => {
+        expect(() => store.putBlockItem(42, "0x424242", "test", {})).to.throw(ApplicationError);
+    });
+
+    fnIt<BlockItemStore<any>>(b => b.withBatch, "rejects with the same error if the callback rejects", async () => {
+        const doh = new Error("Oh no!");
+        expect(store.withBatch(async () => { throw doh })).to.be.rejectedWith(doh);
     });
 
     fnIt<BlockItemStore<any>>(b => b.getBlocksAtHeight, "gets all the blocks at a specific height and correctly reads the `attached` property", async () => {

--- a/test/src/dataEntities/block.test.ts
+++ b/test/src/dataEntities/block.test.ts
@@ -122,6 +122,13 @@ describe("BlockItemStore", () => {
         expect(store.withBatch(async () => { throw doh })).to.be.rejectedWith(doh);
     });
 
+    fnIt<BlockItemStore<any>>(b => b.withBatch, "rejects with ApplicationError if a batch was already open", async () => {
+        await store.withBatch(async () => {
+            expect(store.withBatch(async () => {})).to.be.rejectedWith(ApplicationError);
+        });
+    });
+
+
     fnIt<BlockItemStore<any>>(b => b.getBlocksAtHeight, "gets all the blocks at a specific height and correctly reads the `attached` property", async () => {
         await addSampleData(store);
 

--- a/test/src/responder/component.test.ts
+++ b/test/src/responder/component.test.ts
@@ -86,9 +86,12 @@ describe("ResponderAppointmentReducer", () => {
         await blockStore.start();
 
         blockCache = new BlockCache<ResponderBlock>(100, blockStore);
-        for (const block of blocks) {
-            await blockCache.addBlock(block);
-        }
+
+        await blockStore.withBatch(async () => {
+            for (const block of blocks) {
+                await blockCache.addBlock(block);
+            }
+        })
     });
 
     fnIt<ResponderAppointmentReducer>(r => r.getInitialState, "sets pending tx", () => {

--- a/test/src/responder/component.test.ts
+++ b/test/src/responder/component.test.ts
@@ -94,6 +94,10 @@ describe("ResponderAppointmentReducer", () => {
         })
     });
 
+    afterEach(async () => {
+        await blockStore.stop();
+    });
+
     fnIt<ResponderAppointmentReducer>(r => r.getInitialState, "sets pending tx", () => {
         const reducer = new ResponderAppointmentReducer(blockCache, txID1.identifier, appointmentId1, 0, from1);
 

--- a/test/src/watcher/watcher.test.ts
+++ b/test/src/watcher/watcher.test.ts
@@ -85,6 +85,10 @@ describe("WatcherAppointmentStateReducer", () => {
         });
     });
 
+    after(async () => {
+        await blockStore.stop();
+    });
+
     it("constructor throws ApplicationError if the topics are not set in the filter", () => {
         expect(() => new EventFilterStateReducer(blockCache, { address: "address" }, 0)).to.throw(ApplicationError);
     });
@@ -252,6 +256,10 @@ describe("Watcher", () => {
 
     afterEach(() => {
         resetCalls(mockedResponder);
+    });
+
+    after(async () => {
+        await blockStore.stop();
     });
 
     fnIt<Watcher>(w => w.detectChanges, "calls startResponse after event is OBSERVED for long enough", async () => {

--- a/test/src/watcher/watcher.test.ts
+++ b/test/src/watcher/watcher.test.ts
@@ -70,13 +70,20 @@ describe("WatcherAppointmentStateReducer", () => {
     when(appMock.id).thenReturn("app1");
     when(appMock.startBlock).thenReturn(0);
     when(appMock.endBlock).thenReturn(1000);
-    const appointment = throwingInstance(appMock);
 
     const db = LevelUp(EncodingDown<string, any>(MemDown(), { valueEncoding: "json" }));
     const blockStore = new BlockItemStore<IBlockStub & Logs>(db);
 
     const blockCache = new BlockCache<IBlockStub & Logs>(100, blockStore);
-    blocks.forEach(b => blockCache.addBlock(b));
+
+    before(async () => {
+        await blockStore.start();
+        await blockStore.withBatch(async () => {
+            for (const b of blocks) {
+                await blockCache.addBlock(b);
+            }
+        });
+    });
 
     it("constructor throws ApplicationError if the topics are not set in the filter", () => {
         expect(() => new EventFilterStateReducer(blockCache, { address: "address" }, 0)).to.throw(ApplicationError);
@@ -193,9 +200,8 @@ describe("Watcher", () => {
     const CONFIRMATIONS_BEFORE_REMOVAL = 20;
 
     const db = LevelUp(EncodingDown<string, any>(MemDown(), { valueEncoding: "json" }));
-    const blockStore = new BlockItemStore<IBlockStub & Logs>(db);
-    const blockCache = new BlockCache<IBlockStub & Logs>(100, blockStore);
-    blocks.forEach(b => blockCache.addBlock(b));
+    let blockStore: BlockItemStore<IBlockStub & Logs>;
+    let blockCache: BlockCache<IBlockStub & Logs>;
 
     let mockedStore: AppointmentStore;
     let store: AppointmentStore;
@@ -204,6 +210,19 @@ describe("Watcher", () => {
     let responder: MultiResponder;
 
     let appointment: Appointment;
+
+    before(async () => {
+        blockStore = new BlockItemStore<IBlockStub & Logs>(db);
+        await blockStore.start();
+
+        blockCache = new BlockCache<IBlockStub & Logs>(100, blockStore);
+
+        blockStore.withBatch(async () => {
+            for (const b of blocks) {
+                await blockCache.addBlock(b);
+            }
+        });
+    });
 
     beforeEach(() => {
         const appMock = mock(Appointment);


### PR DESCRIPTION
This follows up on #289 by making sure that the database is always left in a consistent state, by batching together writes that logically belong to the same state update.

Closes: #316.