### PR TITLE
BlockProcessor/BlockCache events cleanup

### DIFF
--- a/packages/block/__tests__/blockProcessor.test.ts
+++ b/packages/block/__tests__/blockProcessor.test.ts
@@ -96,11 +96,11 @@ describe("BlockProcessor", () => {
                     } else {
                         resolve({ number: block.number, hash: block.hash });
                     }
-                    bp.blockCache.newBlock.removeListener(newBlockHandler);
+                    bp.newBlock.removeListener(newBlockHandler);
                 }
             };
 
-            bp.blockCache.newBlock.addListener(newBlockHandler);
+            bp.newBlock.addListener(newBlockHandler);
         });
     };
 
@@ -212,9 +212,9 @@ describe("BlockProcessor", () => {
                 // New head should be the last emitted event
                 newHeadCalledBeforeNewBlock = true;
             }
-            blockCache.newBlock.removeListener(newBlockListener);
+            blockProcessor.newBlock.removeListener(newBlockListener);
         };
-        blockCache.newBlock.addListener(newBlockListener);
+        blockProcessor.newBlock.addListener(newBlockListener);
 
         emitBlockHash("a5");
 
@@ -229,7 +229,7 @@ describe("BlockProcessor", () => {
         blockProcessor = new BlockProcessor(provider, blockStubAndTxHashFactory, blockCache, blockStore, blockProcessorStore);
 
         const subscribers = [];
-        for (let i = 1; i <= 5; i++) {
+        for (let i = 2; i <= 5; i++) { // first block is before the start, so not emitted as new block
             subscribers.push(createNewBlockSubscriber(blockProcessor, blockCache, `a${i}`));
         }
 
@@ -240,8 +240,8 @@ describe("BlockProcessor", () => {
         emitBlockHash("a5");
 
         const results = await Promise.all(subscribers);
-        for (let i = 1; i <= 5; i++) {
-            expect(results[i - 1]).to.deep.equal({
+        for (let i = 2; i <= 5; i++) {
+            expect(results[i - 2]).to.deep.equal({
                 number: i,
                 hash: `a${i}`
             });
@@ -252,7 +252,7 @@ describe("BlockProcessor", () => {
         blockProcessor = new BlockProcessor(provider, blockStubAndTxHashFactory, blockCache, blockStore, blockProcessorStore);
 
         const subscribersA = [];
-        for (let i = 1; i <= 6; i++) {
+        for (let i = 2; i <= 6; i++) {
             subscribersA.push(createNewBlockSubscriber(blockProcessor, blockCache, `a${i}`));
         }
         const subscribersB = [];
@@ -267,8 +267,8 @@ describe("BlockProcessor", () => {
         emitBlockHash("a6");
 
         const resultsA = await Promise.all(subscribersA);
-        for (let i = 1; i <= 6; i++) {
-            expect(resultsA[i - 1]).to.deep.equal({
+        for (let i = 2; i <= 6; i++) {
+            expect(resultsA[i - 2]).to.deep.equal({
                 number: i,
                 hash: `a${i}`
             });

--- a/packages/block/__tests__/blockchainMachine.test.ts
+++ b/packages/block/__tests__/blockchainMachine.test.ts
@@ -83,8 +83,12 @@ class ExampleComponentWithSlowAction extends ExampleComponent {
 }
 
 class MockBlockProcessor {
+    constructor(public readonly blockCache: BlockCache<IBlockStub>) {
+        blockCache.newBlock.addListener(block => this.newBlock.emit(block));
+    }
     public newBlock = new BlockEvent<IBlockStub>();
     public newHead = new BlockEvent<IBlockStub>();
+    public readonly started = true;
 }
 
 describe("BlockchainMachine", () => {
@@ -113,8 +117,7 @@ describe("BlockchainMachine", () => {
         blockCache = new BlockCache<IBlockStub>(100, blockStore);
 
         // Since we only need to process events, we mock the BlockProcessor with an EventEmitter
-        const bp: any = new MockBlockProcessor();
-        bp.blockCache = blockCache;
+        const bp: any = new MockBlockProcessor(blockCache);
         blockProcessor = bp as BlockProcessor<IBlockStub>;
 
         actionStore = new ActionStore(db);

--- a/packages/block/__tests__/blockchainMachine.test.ts
+++ b/packages/block/__tests__/blockchainMachine.test.ts
@@ -83,6 +83,7 @@ class ExampleComponentWithSlowAction extends ExampleComponent {
 }
 
 class MockBlockProcessor {
+    public newBlock = new BlockEvent<IBlockStub>();
     public newHead = new BlockEvent<IBlockStub>();
 }
 

--- a/packages/block/src/blockCache.ts
+++ b/packages/block/src/blockCache.ts
@@ -22,7 +22,6 @@ export type NewBlockListener<TBlock> = (block: TBlock) => Promise<void>;
  * This interface represents the read-only view of a BlockCache.
  */
 export interface ReadOnlyBlockCache<TBlock extends IBlockStub> {
-    newBlock: BlockEvent<TBlock>;
     readonly maxDepth: number;
     readonly maxHeight: number;
     readonly minHeight: number;
@@ -45,7 +44,7 @@ export interface ReadOnlyBlockCache<TBlock extends IBlockStub> {
  *    with respect to the highest block number of an attached block.
  * 2) No block is retained if its height is smaller than the first block ever added.
  * 3) All added blocks are never pruned if their depth is less then `maxDepth`.
- **/
+ */
 export class BlockCache<TBlock extends IBlockStub> implements ReadOnlyBlockCache<TBlock> {
     // Next height to be pruned; the cache will not store a block with height strictly smaller than pruneHeight
     private pruneHeight: number;
@@ -55,6 +54,9 @@ export class BlockCache<TBlock extends IBlockStub> implements ReadOnlyBlockCache
     // As the BlockCache has an on-disk store, a lock is used to serialize parallel write accesses
     private lock = new Lock();
 
+    /**
+     * An event that is generated every time a new block is added to the cache, or a previously unattached block becomes attached.
+     */
     public newBlock = new BlockEvent<TBlock>();
 
     /** True before the first block ever is added */

--- a/packages/block/src/blockchainMachine.ts
+++ b/packages/block/src/blockchainMachine.ts
@@ -45,7 +45,7 @@ export class BlockchainMachine<TBlock extends IBlockStub> extends StartStopServi
         if (!this.blockItemStore.started) this.logger.error("The BlockItemStore should be started before the BlockchainMachine.");
 
         this.blockProcessor.newHead.addListener(this.processNewHead);
-        this.blockProcessor.blockCache.newBlock.addListener(this.processNewBlock);
+        this.blockProcessor.newBlock.addListener(this.processNewBlock);
 
         // For each component, load and start any action that was stored in the ActionStore
         for (const component of this.components) {
@@ -56,7 +56,7 @@ export class BlockchainMachine<TBlock extends IBlockStub> extends StartStopServi
 
     protected async stopInternal(): Promise<void> {
         this.blockProcessor.newHead.removeListener(this.processNewHead);
-        this.blockProcessor.blockCache.newBlock.removeListener(this.processNewBlock);
+        this.blockProcessor.newBlock.removeListener(this.processNewBlock);
     }
 
     constructor(private blockProcessor: BlockProcessor<TBlock>, private actionStore: ActionStore, private blockItemStore: BlockItemStore<TBlock>) {


### PR DESCRIPTION
This PR addresses two issues:
- classes wanting to listen to the "new_block" events would generally have to do something like `blockProcessor.blockCache.newBlock...`, which suggests a bad design. Moreover, the same classes (like the BlockchainMachine) typically also want to listen to the BlockProcessor's `newHead` event, and it was odd to listen to two closely related events from two different sources
- moreover, as the BlockProcessor only emits the new_head events _after_ the service is `started`, there was the incoherent situation where the "new_block" event would be emitted by the blockProcessor prior to completing startup (while adding the block to the cache).

While the logic of the newBlock event is kept in the blockCache, the access to all the other classes (but the blockProcessor) is now granted via the blockProcessor via a proxy, that also makes sure that no events are emitted until the blockProcessor has completed startup.