### PR TITLE
Detect changes for every block

### DIFF
--- a/packages/block/__tests__/blockchainMachine.test.ts
+++ b/packages/block/__tests__/blockchainMachine.test.ts
@@ -42,10 +42,10 @@ const initialState = {
 };
 
 class ExampleReducer implements StateReducer<ExampleState, IBlockStub> {
-    getInitialState(block: IBlockStub) {
+    async getInitialState(block: IBlockStub) {
         return initialState;
     }
-    reduce(prevState: ExampleState, block: IBlockStub) {
+    async reduce(prevState: ExampleState, block: IBlockStub) {
         return {
             someNumber: prevState.someNumber + block.number
         };

--- a/packages/block/__tests__/blockchainMachine.test.ts
+++ b/packages/block/__tests__/blockchainMachine.test.ts
@@ -100,12 +100,6 @@ describe("BlockchainMachine", () => {
     let blockCache: BlockCache<IBlockStub>;
     let actionStore: CachedKeyValueStore<ComponentAction>;
 
-    // Utility function to add a block to the block cache and also emit it as new head in the blockProcessor.
-    const addAndEmitBlock = async (block: IBlockStub) => {
-        await blockCache.addBlock(block);
-        await blockProcessor.newHead.emit(block);
-    };
-
     beforeEach(async () => {
         reducer = new ExampleReducer();
         spiedReducer = spy(reducer);
@@ -140,33 +134,58 @@ describe("BlockchainMachine", () => {
 
     it("processNewBlock computes the initial state if the parent is not in cache", async () => {
         const bm = new BlockchainMachine(blockProcessor, actionStore, blockStore);
-        bm.addComponent(new ExampleComponent(reducer));
+        const component = new ExampleComponent(reducer)
+        bm.addComponent(component);
+        const spiedComponent = spy(component);
         await bm.start();
 
         await blockStore.withBatch(async () => await blockCache.addBlock(blocks[0]));
 
         verify(spiedReducer.getInitialState(blocks[0])).once();
         verify(spiedReducer.reduce(anything(), anything())).never();
+        verify(spiedComponent.applyAction(anything())).never();
+        verify(spiedComponent.detectChanges(anything(), anything())).never();
 
         await bm.stop();
     });
 
     it("processNewBlock computes state with reducer and its parent's initial state if the parent's state is not known", async () => {
         const bm = new BlockchainMachine(blockProcessor, actionStore, blockStore);
-        bm.addComponent(new ExampleComponent(reducer));
+        const component = new ExampleComponent(reducer)
+        bm.addComponent(component);
+        const spiedComponent = spy(component);
         // start only after adding the first block
 
         await blockStore.withBatch(async () => await blockCache.addBlock(blocks[0]));
 
+        verify(spiedComponent.applyAction(anything())).never()
+        verify(spiedComponent.detectChanges(anything(), anything())).never()
+
         await bm.start();
 
         resetCalls(spiedReducer);
+        resetCalls(spiedComponent);
 
         await blockStore.withBatch(async () => await blockCache.addBlock(blocks[1]));
 
         // initializer and reducer should both be called once
         verify(spiedReducer.getInitialState(blocks[0])).once(); // initial state from the parent block
         verify(spiedReducer.reduce(anything(), anything())).once();
+
+        // detect changs and apply action should both be called once
+        verify(spiedComponent.applyAction(anything())).once()
+        verify(spiedComponent.detectChanges(anything(), anything())).once()
+
+
+        // Check that applyAction was called on the right data
+        const [prevState, nextState] = capture(spiedComponent.detectChanges).last();
+        const [actions] = capture(spiedComponent.applyAction).last();
+
+        const nextStateExpected = { someNumber: initialState.someNumber + blocks[1].number };
+        expect(prevState, "prevState is correct").to.deep.equal(initialState);
+        expect(nextState, "nextState is correct").to.deep.equal(nextStateExpected);
+        expect(actions).to.deep.include({ prevState: initialState, newState: nextStateExpected });
+
 
         // Check that the reducer was called on the right data
         const [state, block] = capture(spiedReducer.reduce).last();
@@ -178,7 +197,9 @@ describe("BlockchainMachine", () => {
 
     it("processNewBlock computes the state with the reducer if the parent's state is known", async () => {
         const bm = new BlockchainMachine(blockProcessor, actionStore, blockStore);
-        bm.addComponent(new ExampleComponent(reducer));
+        const component = new ExampleComponent(reducer)
+        bm.addComponent(component);
+        const spiedComponent = spy(component)
 
         // this time we start the BlockchainMachine immediately
         await bm.start();
@@ -189,11 +210,25 @@ describe("BlockchainMachine", () => {
         });
 
         resetCalls(spiedReducer);
+        resetCalls(spiedComponent);
 
         await blockStore.withBatch(async () => await blockCache.addBlock(blocks[2]));
 
         verify(spiedReducer.getInitialState(anything())).never();
         verify(spiedReducer.reduce(anything(), anything())).once();
+
+        verify(spiedComponent.applyAction(anything())).once()
+        verify(spiedComponent.detectChanges(anything(), anything())).once()
+
+        // Check that applyAction was called on the right data
+        const [prevState, nextState] = capture(spiedComponent.detectChanges).last();
+        const [actions] = capture(spiedComponent.applyAction).last();
+
+        const expectedPrevState = { someNumber: initialState.someNumber + blocks[1].number };
+        const nextStateExpected = { someNumber: initialState.someNumber + blocks[1].number + blocks[2].number };
+        expect(prevState, "prevState is correct").to.deep.equal(expectedPrevState);
+        expect(nextState, "nextState is correct").to.deep.equal(nextStateExpected);
+        expect(actions).to.deep.include({ prevState: expectedPrevState, newState: nextStateExpected });
 
         // Check that the reducer was called on the right data
         const [state, block] = capture(spiedReducer.reduce).last();
@@ -210,6 +245,7 @@ describe("BlockchainMachine", () => {
 
         const reducers: ExampleReducer[] = [];
         const spiedReducers: ExampleReducer[] = [];
+        const spiedComponents: ExampleComponent[] = [];
         const nComponents = 3;
         for (let i = 0; i < nComponents; i++) {
             const newReducer = new ExampleReducer();
@@ -217,78 +253,31 @@ describe("BlockchainMachine", () => {
             spiedReducers.push(spy(newReducer));
             const component = new ExampleComponent(newReducer);
             bm.addComponent(component);
+            spiedComponents.push(spy(component))
         }
 
         await bm.start();
 
         await blockStore.withBatch(async () => {
-            await addAndEmitBlock(blocks[0]);
-            await addAndEmitBlock(blocks[1]);
+            await blockCache.addBlock(blocks[0]);
+            await blockCache.addBlock(blocks[1]);
         });
 
         spiedReducers.forEach(r => resetCalls(r));
 
         // State of the parent is { someNumber: 42 + blocks[1].number }
 
-        await blockStore.withBatch(async () => await addAndEmitBlock(blocks[2]));
+        await blockStore.withBatch(async () => await blockCache.addBlock(blocks[2]));
 
         for (let i = 0; i < nComponents; i++) {
             // Check that each reducer was used, but not getInitialState
             verify(spiedReducers[i].getInitialState(anything())).never();
             verify(spiedReducers[i].reduce(anything(), anything())).once();
+
+            // check that all the components were called
+            verify(spiedComponents[i].applyAction(anything()))
+            verify(spiedComponents[i].detectChanges(anything(), anything()))
         }
-
-        await bm.stop();
-    });
-
-    it("processNewHead does not call applyAction before NEW_HEAD_EVENT happens twice", async () => {
-        const bm = new BlockchainMachine(blockProcessor, actionStore, blockStore);
-        const component = new ExampleComponent(reducer);
-        const spiedComponent = spy(component);
-
-        bm.addComponent(component);
-        await bm.start();
-
-        await blockStore.withBatch(async () => await addAndEmitBlock(blocks[0]));
-
-        // some new blocks added to the cache without a new_head event
-        await blockStore.withBatch(async () => {
-            await blockCache.addBlock(blocks[1]);
-            await blockCache.addBlock(blocks[2]);
-        });
-
-        // applyAction should not have been called on the component
-        verify(spiedComponent.detectChanges(anything(), anything())).never();
-        verify(spiedComponent.applyAction(anything())).never();
-
-        await bm.stop();
-    });
-
-    it("processNewHead does call applyAction", async () => {
-        const bm = new BlockchainMachine(blockProcessor, actionStore, blockStore);
-        const component = new ExampleComponent(reducer);
-        const spiedComponent = spy(component);
-
-        bm.addComponent(component);
-        await bm.start();
-
-        await blockStore.withBatch(async () => {
-            await addAndEmitBlock(blocks[0]);
-            await blockCache.addBlock(blocks[1]);
-            await addAndEmitBlock(blocks[2]);
-        });
-
-        verify(spiedComponent.detectChanges(anything(), anything())).once();
-        verify(spiedComponent.applyAction(anything())).once();
-
-        // Check that applyAction was called on the right data
-        const [prevState, nextState] = capture(spiedComponent.detectChanges).last();
-        const [actions] = capture(spiedComponent.applyAction).last();
-
-        const nextStateExpected = { someNumber: initialState.someNumber + blocks[1].number + blocks[2].number };
-        expect(prevState, "prevState is correct").to.deep.equal(initialState);
-        expect(nextState, "nextState is correct").to.deep.equal(nextStateExpected);
-        expect(actions).to.deep.include({ prevState: initialState, newState: nextStateExpected });
 
         await bm.stop();
     });
@@ -305,61 +294,34 @@ describe("BlockchainMachine", () => {
         await bm.start();
 
         await blockStore.withBatch(async () => {
-            await addAndEmitBlock(blocks[0]);
+            await blockCache.addBlock(blocks[0])
             await blockCache.addBlock(blocks[1]);
-            await addAndEmitBlock(blocks[2]);
+            await blockCache.addBlock(blocks[2]);
         });
         // action is still running
 
-        await blockStore.withBatch(async () => await addAndEmitBlock(blocks[3]));
+        await blockStore.withBatch(async () => await blockCache.addBlock(blocks[3]));
 
         // now resolve all actions
         component.resolveActions();
 
         await Promise.resolve();
 
-        const midState = { someNumber: initialState.someNumber + blocks[1].number + blocks[2].number };
+        const firstState = { someNumber: initialState.someNumber + blocks[1].number };
+        const secondState = { someNumber: initialState.someNumber + blocks[1].number + blocks[2].number};
         const finalState = { someNumber: initialState.someNumber + blocks[1].number + blocks[2].number + blocks[3].number };
 
-        const firstAction = { prevState: initialState, newState: midState };
-        const secondAction = { prevState: midState, newState: finalState };
+        const firstAction = { prevState: initialState, newState: firstState };
+        const secondAction = { prevState: secondState, newState: finalState };
 
-        verify(spiedComponent.detectChanges(anything(), anything())).twice();
-        verify(spiedComponent.applyAction(anything())).twice();
+        verify(spiedComponent.detectChanges(anything(), anything())).thrice();
+        verify(spiedComponent.applyAction(anything())).thrice();
 
         // Check that applyAction was called on the right data
         const [action1] = capture(spiedComponent.applyAction).first();
         const [action2] = capture(spiedComponent.applyAction).last();
         expect(action1).to.deep.equal(firstAction);
         expect(action2).to.deep.equal(secondAction);
-
-        await bm.stop();
-    });
-
-    it("processNewHead does call applyAction on multiple components", async () => {
-        const bm = new BlockchainMachine(blockProcessor, actionStore, blockStore);
-        const components: ExampleComponent[] = [];
-        const spiedComponents: ExampleComponent[] = [];
-        const nComponents = 3;
-        for (let i = 0; i < nComponents; i++) {
-            const component = new ExampleComponent(reducer);
-            components.push(component);
-            spiedComponents.push(spy(component));
-            bm.addComponent(component);
-        }
-
-        await bm.start();
-
-        await blockStore.withBatch(async () => {
-            await addAndEmitBlock(blocks[0]);
-            await blockCache.addBlock(blocks[1]);
-            await addAndEmitBlock(blocks[2]);
-        });
-
-        for (let i = 0; i < nComponents; i++) {
-            verify(spiedComponents[i].detectChanges(anything(), anything())).once();
-            verify(spiedComponents[i].applyAction(anything())).once();
-        }
 
         await bm.stop();
     });

--- a/packages/block/__tests__/component.test.ts
+++ b/packages/block/__tests__/component.test.ts
@@ -72,7 +72,7 @@ describe("MappedStateReducer", () => {
         }
     });
 
-    fnIt<MappedStateReducer<any, any, any, any>>(m => m.getInitialState, "computes initial state", () => {
+    fnIt<MappedStateReducer<any, any, any, any>>(m => m.getInitialState, "computes initial state", async () => {
         const msr = new MappedStateReducer<TestAnchorState, {}, IBlockStub, { id: string }>(
             () => [],
             () => new NullReducer(),
@@ -80,14 +80,14 @@ describe("MappedStateReducer", () => {
             new TestAnchorStateReducer(10)
         );
 
-        const initialState = msr.getInitialState(blocks[1]);
+        const initialState = await msr.getInitialState(blocks[1]);
         expect(initialState.someNumber).to.equal(10 + blocks[1].number);
     });
 
-    fnIt<MappedStateReducer<any, any, any, any>>(m => m.getInitialState, "computes initial state on mapped state", () => {
+    fnIt<MappedStateReducer<any, any, any, any>>(m => m.getInitialState, "computes initial state on mapped state", async () => {
         const msr = new MappedStateReducer(() => objects, ({ value }) => new TestAnchorStateReducer(value), o => o.id, new NullReducer());
 
-        const initialState = msr.getInitialState(blocks[0]);
+        const initialState = await msr.getInitialState(blocks[0]);
         expect(Object.keys(initialState)).to.eql(["items"]);
 
         const expectedMap: { [index: string]: TestAnchorState } = {};
@@ -98,7 +98,7 @@ describe("MappedStateReducer", () => {
         expect(initialState.items).to.deep.equal(expectedMap);
     });
 
-    fnIt<MappedStateReducer<any, any, any, any>>(m => m.reduce, "computes reduces state", () => {
+    fnIt<MappedStateReducer<any, any, any, any>>(m => m.reduce, "computes reduces state", async () => {
         const msr = new MappedStateReducer<TestAnchorState, {}, IBlockStub, { id: string }>(
             () => [],
             () => new NullReducer(),
@@ -106,13 +106,13 @@ describe("MappedStateReducer", () => {
             new TestAnchorStateReducer(10)
         );
 
-        const initialState = msr.getInitialState(blocks[1]);
-        const reducedState = msr.reduce(initialState, blocks[2]);
+        const initialState = await msr.getInitialState(blocks[1]);
+        const reducedState = await msr.reduce(initialState, blocks[2]);
 
         expect(reducedState.someNumber).to.equal(10 + blocks[1].number + blocks[2].number);
     });
 
-    fnIt<MappedStateReducer<any, any, any, any>>(m => m.reduce, "computes state on mapped states", () => {
+    fnIt<MappedStateReducer<any, any, any, any>>(m => m.reduce, "computes state on mapped states", async () => {
         const msr = new MappedStateReducer(() => objects, ({ value }) => new TestAnchorStateReducer(value), o => o.id, new NullReducer());
 
         const items: { [index: string]: TestAnchorState } = {};
@@ -121,7 +121,7 @@ describe("MappedStateReducer", () => {
         items[objects[2].id] = { someNumber: objects[2].value };
         const initialState = { items };
 
-        const reducedState = msr.reduce(initialState, blocks[1]);
+        const reducedState = await msr.reduce(initialState, blocks[1]);
 
         expect(Object.keys(reducedState)).to.eql(["items"]);
 
@@ -133,7 +133,7 @@ describe("MappedStateReducer", () => {
         expect(reducedState.items).to.deep.equal(expectedItems);
     });
 
-    fnIt<MappedStateReducer<any, any, any, any>>(m => m.reduce, "calls getInitialState if a new object id is added to the collection", () => {
+    fnIt<MappedStateReducer<any, any, any, any>>(m => m.reduce, "calls getInitialState if a new object id is added to the collection", async () => {
         // start with only two objects
         const items: { [index: string]: TestAnchorState } = {};
         items[objects[0].id] = { someNumber: objects[0].value + blocks[0].number };
@@ -143,7 +143,7 @@ describe("MappedStateReducer", () => {
         // now call the reducer with all the three objects
         const msr = new MappedStateReducer(() => objects, ({ value }) => new TestAnchorStateReducer(value), o => o.id, new NullReducer());
 
-        const reducedState = msr.reduce(initialState, blocks[1]);
+        const reducedState = await msr.reduce(initialState, blocks[1]);
 
         expect(Object.keys(reducedState)).to.eql(["items"]);
 

--- a/packages/block/src/blockCache.ts
+++ b/packages/block/src/blockCache.ts
@@ -173,7 +173,7 @@ export class BlockCache<TBlock extends IBlockStub> implements ReadOnlyBlockCache
 
             if (this.isEmpty) {
                 // First block added, store its height, so blocks before this point will not be stored.
-                this.pruneHeight = block.number;
+                this.pruneHeight = block.number //Math.max(block.number - 100, 0);
                 this.mIsEmpty = false;
             }
 

--- a/packages/block/src/blockItemStore.ts
+++ b/packages/block/src/blockItemStore.ts
@@ -111,15 +111,6 @@ export class BlockItemStore<TBlock extends IBlockStub> extends StartStopService 
             this.putBlockItem(blockHeight, blockHash, `${componentName}:${BlockItemStore.KEY_STATE}`, newState)
     };
 
-    // Type safe methods to store the latest emitted anchor state for each block, indexed by component (used in the BlockchainMachine)
-    // PISA:380: remove these - no longer used
-    public prevEmittedAnchorState = {
-        get: <TAnchorState>(componentName: string, blockHash: string): TAnchorState =>
-            this.getItem(blockHash, `${componentName}:${BlockItemStore.KEY_PREV_EMITTED_STATE}`), // prettier-ignore
-        set: (componentName: string, blockHeight: number, blockHash: string, newPrevEmittedState: AnchorState) =>
-            this.putBlockItem(blockHeight, blockHash, `${componentName}:${BlockItemStore.KEY_PREV_EMITTED_STATE}`, newPrevEmittedState)
-    };
-
     /**
      * Returns the blocks for the specific height, and whether they are attached or not.
      * Blocks are stored under the key `BlockItemStore.KEY_BLOCK`, and wether they are attached is in `BlockItemStore.KEY_ATTACHED`.

--- a/packages/block/src/blockItemStore.ts
+++ b/packages/block/src/blockItemStore.ts
@@ -112,6 +112,7 @@ export class BlockItemStore<TBlock extends IBlockStub> extends StartStopService 
     };
 
     // Type safe methods to store the latest emitted anchor state for each block, indexed by component (used in the BlockchainMachine)
+    // PISA:380: remove these - no longer used
     public prevEmittedAnchorState = {
         get: <TAnchorState>(componentName: string, blockHash: string): TAnchorState =>
             this.getItem(blockHash, `${componentName}:${BlockItemStore.KEY_PREV_EMITTED_STATE}`), // prettier-ignore

--- a/packages/block/src/blockItemStore.ts
+++ b/packages/block/src/blockItemStore.ts
@@ -157,7 +157,7 @@ export class BlockItemStore<TBlock extends IBlockStub> extends StartStopService 
      *
      * @throws ApplicationError if there is already an open batch that did not yet close.
      */
-    public async withBatch(callback: () => Promise<any>) {
+    public async withBatch<TReturn>(callback: () => Promise<TReturn>) {
         if (this.mBatch) {
             throw new ApplicationError("There is already an open batch.");
         }
@@ -165,9 +165,11 @@ export class BlockItemStore<TBlock extends IBlockStub> extends StartStopService 
         try {
             this.mBatch = this.subDb.batch();
 
-            await callback();
+            const callBackResult = await callback();
 
             await this.mBatch.write();
+
+            return callBackResult;
         } finally {
             this.mBatch = null;
         }

--- a/packages/block/src/blockchainMachine.ts
+++ b/packages/block/src/blockchainMachine.ts
@@ -89,9 +89,9 @@ export class BlockchainMachine<TBlock extends IBlockStub> extends StartStopServi
                         // If the parent is available and its anchor state is known, the state can be computed with the reducer.
                         this.blockItemStore.anchorState.get<AnchorState>(component.name, block.parentHash) ||
                         // If the parent is available but its anchor state is not known, first compute its parent's initial state, then apply the reducer.
-                        component.reducer.getInitialState(this.blockProcessor.blockCache.getBlock(block.parentHash));
+                        await component.reducer.getInitialState(this.blockProcessor.blockCache.getBlock(block.parentHash));
 
-                    const newAnchorState = component.reducer.reduce(prevAnchorState, block);
+                    const newAnchorState = await component.reducer.reduce(prevAnchorState, block);
                     this.blockItemStore.anchorState.set(component.name, block.number, block.hash, newAnchorState);
 
                     // having computed a new state we can detect changes and run actions 
@@ -104,7 +104,7 @@ export class BlockchainMachine<TBlock extends IBlockStub> extends StartStopServi
                 }
                 // Finally, if the parent is not available at all in the block cache, compute the initial state based on the current block.
                 else {
-                    const newAnchorState = component.reducer.getInitialState(block);
+                    const newAnchorState = await component.reducer.getInitialState(block);
                     this.blockItemStore.anchorState.set(component.name, block.number, block.hash, newAnchorState);
                 }
             }

--- a/packages/block/src/blockchainMachine.ts
+++ b/packages/block/src/blockchainMachine.ts
@@ -44,7 +44,6 @@ export class BlockchainMachine<TBlock extends IBlockStub> extends StartStopServi
         if (!this.actionStore.started) this.logger.error("The actionStore should be started before the BlockchainMachine.");
         if (!this.blockItemStore.started) this.logger.error("The BlockItemStore should be started before the BlockchainMachine.");
 
-        this.blockProcessor.newHead.addListener(this.processNewHead);
         this.blockProcessor.newBlock.addListener(this.processNewBlock);
 
         // For each component, load and start any action that was stored in the actionStore
@@ -55,13 +54,15 @@ export class BlockchainMachine<TBlock extends IBlockStub> extends StartStopServi
     }
 
     protected async stopInternal(): Promise<void> {
-        this.blockProcessor.newHead.removeListener(this.processNewHead);
         this.blockProcessor.newBlock.removeListener(this.processNewBlock);
     }
 
-    constructor(private blockProcessor: BlockProcessor<TBlock>, private actionStore: CachedKeyValueStore<ComponentAction>, private blockItemStore: BlockItemStore<TBlock>) {
+    constructor(
+        private blockProcessor: BlockProcessor<TBlock>,
+        private actionStore: CachedKeyValueStore<ComponentAction>,
+        private blockItemStore: BlockItemStore<TBlock>
+    ) {
         super("blockchain-machine");
-        this.processNewHead = this.processNewHead.bind(this);
         this.processNewBlock = this.processNewBlock.bind(this);
     }
 
@@ -83,68 +84,29 @@ export class BlockchainMachine<TBlock extends IBlockStub> extends StartStopServi
 
             // Every time a new block is received we calculate the anchor state for that block and store it
             for (const component of this.components) {
-                // If the parent is available and its anchor state is known, the state can be computed with the reducer.
-                // If the parent is available but its anchor state is not known, first compute its parent's initial state, then apply the reducer.
-                // Finally, if the parent is not available at all in the block cache, compute the initial state based on the current block.
-
-                let newState: AnchorState;
-                let prevHeadAnchorState: AnchorState | null = null;
                 if (this.blockProcessor.blockCache.hasBlock(block.parentHash)) {
-                    const parentBlock = this.blockProcessor.blockCache.getBlock(block.parentHash);
-
-                    prevHeadAnchorState = this.blockItemStore.prevEmittedAnchorState.get(component.name, parentBlock.hash);
-
                     const prevAnchorState =
-                        this.blockItemStore.anchorState.get<AnchorState>(component.name, parentBlock.hash) ||
-                        component.reducer.getInitialState(parentBlock); // prettier-ignore
+                        // If the parent is available and its anchor state is known, the state can be computed with the reducer.
+                        this.blockItemStore.anchorState.get<AnchorState>(component.name, block.parentHash) ||
+                        // If the parent is available but its anchor state is not known, first compute its parent's initial state, then apply the reducer.
+                        component.reducer.getInitialState(this.blockProcessor.blockCache.getBlock(block.parentHash));
 
-                    newState = component.reducer.reduce(prevAnchorState, block);
-                } else {
-                    newState = component.reducer.getInitialState(block);
-                }
+                    const newAnchorState = component.reducer.reduce(prevAnchorState, block);
+                    this.blockItemStore.anchorState.set(component.name, block.number, block.hash, newAnchorState);
 
-                this.blockItemStore.anchorState.set(component.name, block.number, block.hash, newState);
-                if (prevHeadAnchorState) {
-                    // copy prevEmittedAnchorState from the previous block
-                    this.blockItemStore.prevEmittedAnchorState.set(component.name, block.number, block.hash, prevHeadAnchorState);
-                }
-            }
-        } finally {
-            this.lock.release();
-        }
-    }
-
-    private async processNewHead(head: Readonly<TBlock>) {
-        try {
-            await this.lock.acquire();
-
-            // The components can specify some behaviour that is computed as a diff
-            // between the old head and the head. We compute this now for each of the
-            // components
-
-            for (const component of this.components) {
-                const state: AnchorState = this.blockItemStore.anchorState.get(component.name, head.hash);
-                if (state == undefined) {
-                    // Since processNewBlock is always called before processNewHead, this should never happen
-                    this.logger.error(
-                        `State for component ${component.constructor.name} for block ${head.hash} (number ${head.number}) was not set, but it should have been.`
-                    );
-                    return;
-                }
-
-                const prevEmittedState: AnchorState | null = this.blockItemStore.prevEmittedAnchorState.get(component.name, head.hash);
-
-                if (prevEmittedState) {
-                    // save actions in the store
-                    const newActions = component.detectChanges(prevEmittedState, state);
+                    // having computed a new state we can detect changes and run actions 
+                    // for the difference between then and now
+                    const newActions = component.detectChanges(prevAnchorState, newAnchorState);
                     if (newActions.length > 0) {
                         const actionAndIds = await this.actionStore.storeItems(component.name, newActions);
                         this.runActionsForComponent(component, actionAndIds);
                     }
                 }
-
-                // this is now the latest anchor stated for an emitted head block; update the store accordingly
-                this.blockItemStore.prevEmittedAnchorState.set(component.name, head.number, head.hash, state);
+                // Finally, if the parent is not available at all in the block cache, compute the initial state based on the current block.
+                else {
+                    const newAnchorState = component.reducer.getInitialState(block);
+                    this.blockItemStore.anchorState.set(component.name, block.number, block.hash, newAnchorState);
+                }
             }
         } finally {
             this.lock.release();

--- a/packages/server/src/service/service.ts
+++ b/packages/server/src/service/service.ts
@@ -160,8 +160,8 @@ export class PisaService extends StartStopService {
     protected async startInternal() {
         await this.blockItemStore.start();
         await this.actionStore.start();
-        await this.blockchainMachine.start();
         await this.blockProcessor.start();
+        await this.blockchainMachine.start();
         await this.appointmentStore.start();
         await this.responderStore.start();
     }
@@ -169,8 +169,8 @@ export class PisaService extends StartStopService {
     protected async stopInternal() {
         await this.responderStore.stop();
         await this.appointmentStore.stop();
-        await this.blockProcessor.stop();
         await this.blockchainMachine.stop();
+        await this.blockProcessor.stop();
         await this.actionStore.stop();
         await this.blockItemStore.stop();
 


### PR DESCRIPTION
We need detectChanges to be called on every block. See #380 . But at the moment we only detect changes/emit when have a new head. New heads can be emitted very far apart and not all the blocks between them may be in the cache. So, if we want this functionality, I think we have 2 choices,

1. Emit heads closer together so that all blocks in between are in the cache
2. Stop detecting changes on new head and instead do it the new block event

We originally had both new head and new block events because we wanted to aggregate changes over large periods of time, since some actions may cancel each other out. However in practice we have to program as if the actions come one at a time as this is what will happen for short gaps between blocks, which is the norm. So bulk detectChanges is just an optimisation, not absolutely necessary. So I've gone for option 2, and we now no longer use the newHead in the blockchain machine.