### PR TITLE
Fix BlockCache bug in attaching detached blocks in the presence of reorgs

### DIFF
--- a/packages/block/src/blockCache.ts
+++ b/packages/block/src/blockCache.ts
@@ -118,7 +118,8 @@ export class BlockCache<TBlock extends IBlockStub> implements ReadOnlyBlockCache
      */
     private async processDetached(height: number) {
         const blocksAtHeight = this.blockStore.getBlocksAtHeight(height);
-        const blocksToAdd = blocksAtHeight.filter(b => !b.attached);
+        // Filter the blocks at the given height that can actually be attached
+        const blocksToAdd = blocksAtHeight.filter(b => !b.attached && this.canAttachBlock(b.block));
 
         for (const { block } of blocksToAdd) {
             // Update the block in the db (as it is now attached)

--- a/packages/block/src/blockCache.ts
+++ b/packages/block/src/blockCache.ts
@@ -1,5 +1,5 @@
 import { ApplicationError, ArgumentError } from "@pisa-research/errors";
-import { IBlockStub, TransactionHashes } from "./block";
+import { IBlockStub } from "./block";
 import { BlockItemStore } from "./blockItemStore";
 import { Lock } from "@pisa-research/utils";
 import { BlockEvent } from "./event";
@@ -92,7 +92,9 @@ export class BlockCache<TBlock extends IBlockStub> implements ReadOnlyBlockCache
      */
     constructor(public readonly maxDepth: number, private readonly blockStore: BlockItemStore<TBlock>) {}
 
-    /** Remove all the blocks that are deeper than maxDepth, and all connected information. */
+    /**
+     * Removes all the blocks that are deeper than maxDepth, and all connected information.
+     **/
     private async prune() {
         while (this.pruneHeight < this.minHeight && this.headSet && this.pruneHeight < this.head.number) {
             this.blockStore.deleteItemsAtHeight(this.pruneHeight);
@@ -290,7 +292,7 @@ export class BlockCache<TBlock extends IBlockStub> implements ReadOnlyBlockCache
     }
 
     /**
-     * Sets the head block in the cache. AddBlock must be called before setHead can be
+     * Sets the head block in the cache. `addBlock` must be called before `setHead` can be
      * called for that hash, and the block must be attached.
      * @param blockHash
      */
@@ -314,20 +316,4 @@ export class BlockCache<TBlock extends IBlockStub> implements ReadOnlyBlockCache
         }
         return this.getBlock(this.headHash);
     }
-}
-
-/**
- * Gets the number of confirmations of the transaction with hash `txHash`, assuming that the block with hash
- * `headHash` is the head of the blockchain.
- * Return 0 if no such transaction was found in any ancestor block in the cache.
- * @param cache
- * @param headHash
- * @param txHash
- * @throws `ArgumentError` if the block with hash `headHash` is not in the cache or is not attached.
- */
-export function getConfirmations<T extends IBlockStub & TransactionHashes>(cache: ReadOnlyBlockCache<T>, headHash: string, txHash: string): number {
-    const headBlock = cache.getBlock(headHash);
-    const blockTxIsMinedIn = cache.findAncestor(headHash, block => block.transactionHashes.includes(txHash));
-    if (!blockTxIsMinedIn) return 0;
-    else return headBlock.number - blockTxIsMinedIn.number + 1;
 }

--- a/packages/block/src/index.ts
+++ b/packages/block/src/index.ts
@@ -8,7 +8,7 @@ export {
     TransactionStub,
     hasLogMatchingEventFilter
 } from "./block";
-export { ReadOnlyBlockCache, BlockCache, getConfirmations, BlockAddResult, NewBlockListener } from "./blockCache";
+export { ReadOnlyBlockCache, BlockCache, BlockAddResult, NewBlockListener } from "./blockCache";
 export { BlockchainMachineService, BlockchainMachine } from "./blockchainMachine";
 export { BlockItemStore } from "./blockItemStore";
 export { BlockProcessor, blockStubAndTxHashFactory, blockFactory, BlockProcessorStore, NewHeadListener } from "./blockProcessor";


### PR DESCRIPTION
The fix is 1 line in  BlockCache.processDetached. The rest of the diff is:
- the test for the bug condition
- improvements on the BlockCache tests (generateBlocks had an off-by-one)
- removed stale function `getConfirmation` and its tests; we're not using it.
